### PR TITLE
refactor: optimize memory usage in the image downloader class

### DIFF
--- a/components/media_player/sources/utils_mediaplayer.cpp
+++ b/components/media_player/sources/utils_mediaplayer.cpp
@@ -32,8 +32,9 @@ MediaPlayerUtils::MediaPlayerUtils() {}
 MediaPlayerUtils::~MediaPlayerUtils() {
     if (m_workerThread->isRunning()) {
         qCDebug(CLASS_LC()) << "Destructor: Thread is running. Quitting.";
+        m_worker->terminateWork();
         m_workerThread->quit();
-        if (!m_workerThread->wait(3000)) {
+        if (!m_workerThread->wait(5000)) {
             qCWarning(CLASS_LC()) << "Destructor: Thread didn't quit. Terminating.";
             m_workerThread->terminate();
             m_workerThread->wait();
@@ -47,11 +48,6 @@ MediaPlayerUtils::~MediaPlayerUtils() {
         m_worker->deleteLater();
         m_worker = nullptr;
         qCDebug(CLASS_LC()) << "Destructor: Worker class deleted";
-    }
-    if (m_manager) {
-        m_manager->deleteLater();
-        m_manager = nullptr;
-        qCDebug(CLASS_LC()) << "Destructor: QNetworkAccessManager deleted";
     }
 }
 
@@ -86,9 +82,10 @@ void MediaPlayerUtils::onProcessingDone(const QColor &pixelColor, const QString 
     emit imageChanged();
 
     if (m_workerThread->isRunning()) {
+        m_worker->terminateWork();
         qCDebug(CLASS_LC()) << "Thread is running. Quitting.";
         m_workerThread->quit();
-        if (!m_workerThread->wait(3000)) {
+        if (!m_workerThread->wait(5000)) {
             qCWarning(CLASS_LC()) << "Thread didn't quit. Terminating.";
             m_workerThread->terminate();
             m_workerThread->wait();
@@ -101,35 +98,55 @@ void MediaPlayerUtils::onProcessingDone(const QColor &pixelColor, const QString 
     m_worker->deleteLater();
     m_worker = nullptr;
     qCDebug(CLASS_LC()) << "Worker class deleted";
-    m_manager->deleteLater();
-    m_manager = nullptr;
-    qCDebug(CLASS_LC()) << "QNetworkAccessManager deleted";
 }
 
 void MediaPlayerUtils::generateImages(const QString &url) {
     if (url != m_prevImageURL) {
         m_prevImageURL = url;
         emit processingStarted();
-        m_worker = new MediaPlayerUtilsWorker();
 
-        m_manager = new QNetworkAccessManager(this);
-        connect(m_manager, &QNetworkAccessManager::finished, m_worker, &MediaPlayerUtilsWorker::generateImagesReply);
-
+        m_worker       = new MediaPlayerUtilsWorker();
         m_workerThread = new QThread();
+
         connect(m_worker, &MediaPlayerUtilsWorker::processingDone, this, &MediaPlayerUtils::onProcessingDone);
+        //        connect(this, &MediaPlayerUtils::generateImagesSignal, m_worker,
+        //        &MediaPlayerUtilsWorker::generateImages);
+
         m_worker->moveToThread(m_workerThread);
         m_workerThread->start();
-
-        m_manager->get(QNetworkRequest(QUrl(url)));
+        m_worker->generateImages(url);
     }
 }
 
-void MediaPlayerUtilsWorker::generateImagesReply(QNetworkReply *reply) {
-    if (reply->error() == QNetworkReply::NoError) {
+MediaPlayerUtilsWorker::~MediaPlayerUtilsWorker() {
+    qCDebug(CLASS_LC()) << "Worker destructor: terminate work.";
+    m_manager->disconnect();
+    m_manager->deleteLater();
+    m_manager = nullptr;
+    qCDebug(CLASS_LC()) << "Worker destructor: Manager deleted.";
+}
+
+void MediaPlayerUtilsWorker::terminateWork() {
+    qCDebug(CLASS_LC()) << "Worker: terminate work.";
+    m_manager->disconnect();
+    m_manager->deleteLater();
+    m_manager = nullptr;
+    qCDebug(CLASS_LC()) << "Worker: Manager deleted.";
+}
+
+void MediaPlayerUtilsWorker::generateImages(const QString &url) {
+    m_manager = new QNetworkAccessManager();
+    m_reply   = m_manager->get(QNetworkRequest(QUrl(url)));
+
+    connect(m_reply, &QNetworkReply::finished, this, &MediaPlayerUtilsWorker::generateImagesReply);
+}
+
+void MediaPlayerUtilsWorker::generateImagesReply() {
+    if (m_reply->error() == QNetworkReply::NoError) {
         // run image processing in different thread
         QImage image;
 
-        if (!image.load(reply, nullptr)) {
+        if (!image.load(m_reply, nullptr)) {
             qCWarning(CLASS_LC) << "ERROR LOADING IMAGE";
             return;
         } else {
@@ -203,17 +220,16 @@ void MediaPlayerUtilsWorker::generateImagesReply(QNetworkReply *reply) {
             qCDebug(CLASS_LC()) << "Creating large image DONE";
 
             emit processingDone(m_pixelColor, m_smallImage, m_largeImage);
-            if (reply) {
-                reply->deleteLater();
-                reply = nullptr;
-            }
-            qCDebug(CLASS_LC()) << "Network reply deleted";
         }
     } else {
-        qCWarning(CLASS_LC) << "NETWORK REPLY ERROR" << reply->errorString();
+        qCWarning(CLASS_LC) << "NETWORK REPLY ERROR" << m_reply->errorString();
         emit processingDone(QColor("black"), "", "");
-        return;
     }
+    if (m_reply) {
+        m_reply->deleteLater();
+        m_reply = nullptr;
+    }
+    qCDebug(CLASS_LC()) << "Network reply deleted";
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/components/media_player/sources/utils_mediaplayer.cpp
+++ b/components/media_player/sources/utils_mediaplayer.cpp
@@ -86,10 +86,10 @@ void MediaPlayerUtils::onProcessingDone(const QColor &pixelColor, const QString 
             m_workerThread->terminate();
             m_workerThread->wait();
             qCWarning(CLASS_LC()) << "Thread terminated.";
+            m_workerThread->deleteLater();
+            qCDebug(CLASS_LC()) << "Thread removed and deleted";
         }
     }
-    m_workerThread->deleteLater();
-    qCDebug(CLASS_LC()) << "Thread removed and deleted";
     m_worker->deleteLater();
     qCDebug(CLASS_LC()) << "Worker class deleted";
     m_manager->deleteLater();
@@ -193,8 +193,10 @@ void MediaPlayerUtilsWorker::generateImagesReply(QNetworkReply *reply) {
             qCDebug(CLASS_LC()) << "Creating large image DONE";
 
             emit processingDone(m_pixelColor, m_smallImage, m_largeImage);
-
-            reply->deleteLater();
+            if (reply) {
+                reply->deleteLater();
+                reply = nullptr;
+            }
             qCDebug(CLASS_LC()) << "Network reply deleted";
         }
     } else {

--- a/components/media_player/sources/utils_mediaplayer.cpp
+++ b/components/media_player/sources/utils_mediaplayer.cpp
@@ -38,10 +38,10 @@ MediaPlayerUtils::~MediaPlayerUtils() {
             m_workerThread->terminate();
             m_workerThread->wait();
             qCWarning(CLASS_LC()) << "Destructor: Thread terminated.";
+            m_workerThread->deleteLater();
+            qCDebug(CLASS_LC()) << "Destructor: Thread removed and deleted";
         }
     }
-    m_workerThread->deleteLater();
-    qCDebug(CLASS_LC()) << "Destructor: Thread removed and deleted";
     m_worker->deleteLater();
     qCDebug(CLASS_LC()) << "Destructor: Worker class deleted";
     m_manager->deleteLater();

--- a/components/media_player/sources/utils_mediaplayer.cpp
+++ b/components/media_player/sources/utils_mediaplayer.cpp
@@ -39,13 +39,20 @@ MediaPlayerUtils::~MediaPlayerUtils() {
             m_workerThread->wait();
             qCWarning(CLASS_LC()) << "Destructor: Thread terminated.";
             m_workerThread->deleteLater();
+            m_workerThread = nullptr;
             qCDebug(CLASS_LC()) << "Destructor: Thread removed and deleted";
         }
     }
-    m_worker->deleteLater();
-    qCDebug(CLASS_LC()) << "Destructor: Worker class deleted";
-    m_manager->deleteLater();
-    qCDebug(CLASS_LC()) << "Destructor: QNetworkAccessManager deleted";
+    if (m_worker) {
+        m_worker->deleteLater();
+        m_worker = nullptr;
+        qCDebug(CLASS_LC()) << "Destructor: Worker class deleted";
+    }
+    if (m_manager) {
+        m_manager->deleteLater();
+        m_manager = nullptr;
+        qCDebug(CLASS_LC()) << "Destructor: QNetworkAccessManager deleted";
+    }
 }
 
 void MediaPlayerUtils::setImageURL(QString url) {
@@ -87,12 +94,15 @@ void MediaPlayerUtils::onProcessingDone(const QColor &pixelColor, const QString 
             m_workerThread->wait();
             qCWarning(CLASS_LC()) << "Thread terminated.";
             m_workerThread->deleteLater();
+            m_workerThread = nullptr;
             qCDebug(CLASS_LC()) << "Thread removed and deleted";
         }
     }
     m_worker->deleteLater();
+    m_worker = nullptr;
     qCDebug(CLASS_LC()) << "Worker class deleted";
     m_manager->deleteLater();
+    m_manager = nullptr;
     qCDebug(CLASS_LC()) << "QNetworkAccessManager deleted";
 }
 

--- a/components/media_player/sources/utils_mediaplayer.h
+++ b/components/media_player/sources/utils_mediaplayer.h
@@ -36,16 +36,21 @@ class MediaPlayerUtilsWorker : public QObject {
 
  public:
     MediaPlayerUtilsWorker() {}
-    virtual ~MediaPlayerUtilsWorker() {}
+    virtual ~MediaPlayerUtilsWorker();
+
+    void terminateWork();
 
  public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
-    void generateImagesReply(QNetworkReply* reply);
+    void generateImages(const QString& url);
+    void generateImagesReply();
 
  signals:
     void processingDone(const QColor& pixelColor, const QString& smallImage, const QString& largeImage);
 
  private:
-    QColor dominantColor(const QImage& image);
+    QNetworkAccessManager* m_manager;
+    QNetworkReply*         m_reply;
+    QColor                 dominantColor(const QImage& image);
 };
 
 class MediaPlayerUtils : public QObject {
@@ -91,7 +96,6 @@ class MediaPlayerUtils : public QObject {
 
     void generateImages(const QString& url);
 
-    QNetworkAccessManager*  m_manager;
     QThread*                m_workerThread;
     MediaPlayerUtilsWorker* m_worker;
 };


### PR DESCRIPTION
No need to keep the worker thread and network access manager, when they are not doing anything. I observed significant less memory usage by doing this.