### PR TITLE
feat: Use QQuickImageProvider to draw album art

### DIFF
--- a/basic_ui/CustomImageLoader.qml
+++ b/basic_ui/CustomImageLoader.qml
@@ -47,7 +47,7 @@ Item {
         id: image1
         anchors.fill: parent
         fillMode: Image.PreserveAspectCrop
-        asynchronous: true
+        asynchronous: false
         cache: false
 
         onStatusChanged: {
@@ -61,7 +61,7 @@ Item {
         id: image2
         anchors.fill: parent
         fillMode: Image.PreserveAspectCrop
-        asynchronous: true
+        asynchronous: false
         opacity: 0
         cache: false
 

--- a/basic_ui/CustomImageLoader.qml
+++ b/basic_ui/CustomImageLoader.qml
@@ -48,6 +48,7 @@ Item {
         anchors.fill: parent
         fillMode: Image.PreserveAspectCrop
         asynchronous: true
+        cache: false
 
         onStatusChanged: {
             if (image1.status == Image.Ready) {
@@ -62,6 +63,7 @@ Item {
         fillMode: Image.PreserveAspectCrop
         asynchronous: true
         opacity: 0
+        cache: false
 
         Behavior on opacity {
             NumberAnimation { duration: 800; easing.type: Easing.OutExpo }

--- a/basic_ui/MiniMediaPlayer.qml
+++ b/basic_ui/MiniMediaPlayer.qml
@@ -208,6 +208,7 @@ Item {
                     onImageChanged: {
                         bgImage.stopLoader();
                         image.stopLoader();
+                        counter = !counter
                     }
                 }
 
@@ -348,7 +349,6 @@ Item {
                     property var m_image: obj ? obj.mediaImage : ""
 
                     onM_imageChanged: {
-                        counter = !counter
                         if (obj) {
                             mediaplayerUtils.imageURL = obj.mediaImage
                         }
@@ -358,7 +358,7 @@ Item {
                         id: bgImage
                         width: 280; height: 280
                         anchors { horizontalCenter: parent.horizontalCenter; top: parent.top; topMargin: 86 }
-                        url: "image://mediautilsprovider/image?id=" + counter //obj && obj.mediaImage === "" ? "qrc:/images/mini-music-player/no_image.png" : mediaplayerUtils.image //utils.miniMusicPlayerImage
+                        url: "image://" + mediaplayerUtils.imageProviderId + "/image?id=" + counter //obj && obj.mediaImage === "" ? "qrc:/images/mini-music-player/no_image.png" : mediaplayerUtils.image //utils.miniMusicPlayerImage
                     }
                 }
 
@@ -366,7 +366,7 @@ Item {
                     id: image
                     width: 90; height: 90
                     anchors { verticalCenter: parent.verticalCenter; left: parent.left; leftMargin: 0 }
-                    url: "image://mediautilsprovider/image?id=" + counter //obj && obj.mediaImage === "" ? "qrc:/images/mini-music-player/no_image.png" : mediaplayerUtils.smallImage
+                    url: "image://" + mediaplayerUtils.imageProviderId + "/image?id=" + counter //obj && obj.mediaImage === "" ? "qrc:/images/mini-music-player/no_image.png" : mediaplayerUtils.smallImage
                 }
 
                 Item {

--- a/basic_ui/MiniMediaPlayer.qml
+++ b/basic_ui/MiniMediaPlayer.qml
@@ -40,6 +40,8 @@ Item {
     width: Style.screen.width; height: 90
     anchors.bottom: parent.bottom
 
+    property bool counter: false
+
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // STATES
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -346,6 +348,7 @@ Item {
                     property var m_image: obj ? obj.mediaImage : ""
 
                     onM_imageChanged: {
+                        counter = !counter
                         if (obj) {
                             mediaplayerUtils.imageURL = obj.mediaImage
                         }
@@ -355,7 +358,7 @@ Item {
                         id: bgImage
                         width: 280; height: 280
                         anchors { horizontalCenter: parent.horizontalCenter; top: parent.top; topMargin: 86 }
-                        url: obj && obj.mediaImage === "" ? "qrc:/images/mini-music-player/no_image.png" : mediaplayerUtils.image //utils.miniMusicPlayerImage
+                        url: "image://mediautilsprovider/image?id=" + counter //obj && obj.mediaImage === "" ? "qrc:/images/mini-music-player/no_image.png" : mediaplayerUtils.image //utils.miniMusicPlayerImage
                     }
                 }
 
@@ -363,7 +366,7 @@ Item {
                     id: image
                     width: 90; height: 90
                     anchors { verticalCenter: parent.verticalCenter; left: parent.left; leftMargin: 0 }
-                    url: obj && obj.mediaImage === "" ? "qrc:/images/mini-music-player/no_image.png" : mediaplayerUtils.smallImage
+                    url: "image://mediautilsprovider/image?id=" + counter //obj && obj.mediaImage === "" ? "qrc:/images/mini-music-player/no_image.png" : mediaplayerUtils.smallImage
                 }
 
                 Item {

--- a/components/media_player/sources/utils_mediaplayer.cpp
+++ b/components/media_player/sources/utils_mediaplayer.cpp
@@ -74,6 +74,11 @@ MediaPlayerUtils::~MediaPlayerUtils() {
             qCDebug(CLASS_LC()) << "Destructor: Worker thread deleted";
         }
     }
+
+    m_startTimer    = nullptr;
+    m_engine        = nullptr;
+    m_imageProvider = nullptr;
+
     qCDebug(CLASS_LC()) << "Destructor end";
 }
 

--- a/components/media_player/sources/utils_mediaplayer.cpp
+++ b/components/media_player/sources/utils_mediaplayer.cpp
@@ -27,7 +27,11 @@
 
 static Q_LOGGING_CATEGORY(CLASS_LC, "mediaplayer utils");
 
-MediaPlayerUtils::MediaPlayerUtils(QObject *parent) : QObject(parent) {}
+MediaPlayerUtils::MediaPlayerUtils(QObject *parent) : QObject(parent) {
+    m_startTimer = new QTimer(this);
+    m_startTimer->setSingleShot(true);
+    m_startTimer->setInterval(1000);
+}
 
 MediaPlayerUtils::~MediaPlayerUtils() {
     qCDebug(CLASS_LC()) << "Destructor called";
@@ -68,7 +72,11 @@ void MediaPlayerUtils::setImageURL(QString url) {
     m_imageURL = url;
 
     if (m_imageURL != m_prevImageURL && m_enabled && !m_imageURL.isEmpty()) {
-        generateImages(m_imageURL);
+        if (m_startTimer->isActive()) {
+            m_startTimer->stop();
+        }
+        QObject::connect(m_startTimer, &QTimer::timeout, this, [=] { generateImages(m_imageURL); });
+        m_startTimer->start();
     }
 }
 

--- a/components/media_player/sources/utils_mediaplayer.cpp
+++ b/components/media_player/sources/utils_mediaplayer.cpp
@@ -44,6 +44,9 @@ MediaPlayerUtils::MediaPlayerUtils(QObject *parent) : QObject(parent) {
 
 MediaPlayerUtils::~MediaPlayerUtils() {
     qCDebug(CLASS_LC()) << "Destructor called";
+    m_engine->removeImageProvider(m_imageProviderId);
+    qCDebug(CLASS_LC()) << "Image provider removed:" << m_imageProviderId;
+
     if (m_worker != nullptr) {
         m_worker->disconnect();
         qCDebug(CLASS_LC()) << "Destructor: signal disconnected from Worker class";

--- a/components/media_player/sources/utils_mediaplayer.cpp
+++ b/components/media_player/sources/utils_mediaplayer.cpp
@@ -53,6 +53,8 @@ MediaPlayerUtils::~MediaPlayerUtils() {
         qCDebug(CLASS_LC()) << "Destructor: signal disconnected from Worker class";
     }
 
+    qCDebug(CLASS_LC()) << "Destructor: Worker was null moving on";
+
     if (m_workerThread != nullptr) {
         if (m_workerThread->isRunning()) {
             qCDebug(CLASS_LC()) << "Destructor: Worker thread is running";
@@ -61,27 +63,41 @@ MediaPlayerUtils::~MediaPlayerUtils() {
                 qCDebug(CLASS_LC()) << "Destructor: Terminating worker thread";
                 m_workerThread->terminate();
                 m_workerThread->wait();
+                delete m_worker;
                 m_worker = nullptr;
                 qCDebug(CLASS_LC()) << "Destructor: Worker class deleted";
+                delete m_workerThread;
                 m_workerThread = nullptr;
                 qCDebug(CLASS_LC()) << "Destructor: Worker thread deleted";
             } else {
+                delete m_worker;
                 m_worker = nullptr;
                 qCDebug(CLASS_LC()) << "Destructor: Worker class deleted";
+                delete m_workerThread;
                 m_workerThread = nullptr;
                 qCDebug(CLASS_LC()) << "Destructor: Worker thread deleted";
             }
         } else {
+            delete m_worker;
             m_worker = nullptr;
             qCDebug(CLASS_LC()) << "Destructor: Worker class deleted";
+            delete m_workerThread;
             m_workerThread = nullptr;
             qCDebug(CLASS_LC()) << "Destructor: Worker thread deleted";
         }
     }
 
-    m_startTimer    = nullptr;
-    m_engine        = nullptr;
+    qCDebug(CLASS_LC()) << "Destructor: WorkerThread was null moving on";
+
+    if (m_startTimer->isActive()) {
+        m_startTimer->stop();
+    }
+    delete m_startTimer;
+    m_startTimer = nullptr;
+    m_engine     = nullptr;
+    delete m_engine;
     m_imageProvider = nullptr;
+    delete m_imageProvider;
 
     qCDebug(CLASS_LC()) << "Destructor end";
 }
@@ -129,19 +145,25 @@ void MediaPlayerUtils::onProcessingDone(const QColor &pixelColor, const QImage &
                 qCDebug(CLASS_LC()) << "Terminating worker thread";
                 m_workerThread->terminate();
                 m_workerThread->wait();
+                delete m_worker;
                 m_worker = nullptr;
                 qCDebug(CLASS_LC()) << "Worker class deleted";
+                delete m_workerThread;
                 m_workerThread = nullptr;
                 qCDebug(CLASS_LC()) << "Worker thread deleted";
             } else {
+                delete m_worker;
                 m_worker = nullptr;
                 qCDebug(CLASS_LC()) << "Worker class deleted";
+                delete m_workerThread;
                 m_workerThread = nullptr;
                 qCDebug(CLASS_LC()) << "Worker thread deleted";
             }
         } else {
+            delete m_worker;
             m_worker = nullptr;
             qCDebug(CLASS_LC()) << "Worker class deleted";
+            delete m_workerThread;
             m_workerThread = nullptr;
             qCDebug(CLASS_LC()) << "Worker thread deleted";
         }
@@ -190,6 +212,7 @@ void MediaPlayerUtilsWorker::generateImagesReply() {
             qCWarning(CLASS_LC) << "ERROR LOADING IMAGE";
             if (m_reply) {
                 m_reply->deleteLater();
+                m_reply = nullptr;
             }
             return;
         } else {
@@ -241,6 +264,7 @@ void MediaPlayerUtilsWorker::generateImagesReply() {
     }
     if (m_reply) {
         m_reply->deleteLater();
+        m_reply = nullptr;
     }
     qCDebug(CLASS_LC()) << "Network reply deleted";
 }

--- a/components/media_player/sources/utils_mediaplayer.cpp
+++ b/components/media_player/sources/utils_mediaplayer.cpp
@@ -182,10 +182,14 @@ void MediaPlayerUtilsWorker::generateImages(const QString &url) {
 void MediaPlayerUtilsWorker::generateImagesReply() {
     if (m_reply->error() == QNetworkReply::NoError) {
         // run image processing in different thread
-        QImage image;
+        QImage image(280, 280, QImage::Format_RGB888);
+        image.fill(Qt::black);
 
         if (!image.load(m_reply, nullptr)) {
             qCWarning(CLASS_LC) << "ERROR LOADING IMAGE";
+            if (m_reply) {
+                m_reply->deleteLater();
+            }
             return;
         } else {
             ////////////////////////////////////////////////////////////////////
@@ -234,7 +238,9 @@ void MediaPlayerUtilsWorker::generateImagesReply() {
         qCWarning(CLASS_LC) << "NETWORK REPLY ERROR" << m_reply->errorString();
         emit processingDone(QColor("black"), QImage());
     }
-    m_reply->deleteLater();
+    if (m_reply) {
+        m_reply->deleteLater();
+    }
     qCDebug(CLASS_LC()) << "Network reply deleted";
 }
 
@@ -275,7 +281,8 @@ MediaPlayerUtilsImageProvider *MediaPlayerUtilsImageProvider::s_instance = nullp
 MediaPlayerUtilsImageProvider::MediaPlayerUtilsImageProvider() : QQuickImageProvider(QQuickImageProvider::Image) {
     s_instance = this;
 
-    m_noImage = QImage();
+    m_noImage = QImage(280, 280, QImage::Format_RGB888);
+    m_noImage.fill(Qt::black);
     blockSignals(false);
 }
 

--- a/components/media_player/sources/utils_mediaplayer.cpp
+++ b/components/media_player/sources/utils_mediaplayer.cpp
@@ -51,43 +51,20 @@ MediaPlayerUtils::~MediaPlayerUtils() {
     if (m_worker != nullptr) {
         m_worker->disconnect();
         qCDebug(CLASS_LC()) << "Destructor: signal disconnected from Worker class";
+        delete m_worker;
+        m_worker = nullptr;
+        qCDebug(CLASS_LC()) << "Destructor: worker deleted";
     }
-
-    qCDebug(CLASS_LC()) << "Destructor: Worker was null moving on";
 
     if (m_workerThread != nullptr) {
         if (m_workerThread->isRunning()) {
-            qCDebug(CLASS_LC()) << "Destructor: Worker thread is running";
             m_workerThread->quit();
-            if (!m_workerThread->wait(5000)) {
-                qCDebug(CLASS_LC()) << "Destructor: Terminating worker thread";
-                m_workerThread->terminate();
-                m_workerThread->wait();
-                delete m_worker;
-                m_worker = nullptr;
-                qCDebug(CLASS_LC()) << "Destructor: Worker class deleted";
-                delete m_workerThread;
-                m_workerThread = nullptr;
-                qCDebug(CLASS_LC()) << "Destructor: Worker thread deleted";
-            } else {
-                delete m_worker;
-                m_worker = nullptr;
-                qCDebug(CLASS_LC()) << "Destructor: Worker class deleted";
-                delete m_workerThread;
-                m_workerThread = nullptr;
-                qCDebug(CLASS_LC()) << "Destructor: Worker thread deleted";
-            }
-        } else {
-            delete m_worker;
-            m_worker = nullptr;
-            qCDebug(CLASS_LC()) << "Destructor: Worker class deleted";
+            m_workerThread->wait();
             delete m_workerThread;
             m_workerThread = nullptr;
-            qCDebug(CLASS_LC()) << "Destructor: Worker thread deleted";
+            qCDebug(CLASS_LC()) << "Destructor: WorkerThread was deleted";
         }
     }
-
-    qCDebug(CLASS_LC()) << "Destructor: WorkerThread was null moving on";
 
     if (m_startTimer->isActive()) {
         m_startTimer->stop();
@@ -135,39 +112,22 @@ void MediaPlayerUtils::onProcessingDone(const QColor &pixelColor, const QImage &
     if (m_worker != nullptr) {
         m_worker->disconnect();
         qCDebug(CLASS_LC()) << "Signal disconnected from Worker class";
+        delete m_worker;
+        m_worker = nullptr;
+        qCDebug(CLASS_LC()) << "Worker deleted";
     }
 
     if (m_workerThread != nullptr) {
         if (m_workerThread->isRunning()) {
-            qCDebug(CLASS_LC()) << "Worker thread is running";
             m_workerThread->quit();
-            if (!m_workerThread->wait(5000)) {
-                qCDebug(CLASS_LC()) << "Terminating worker thread";
-                m_workerThread->terminate();
-                m_workerThread->wait();
-                delete m_worker;
-                m_worker = nullptr;
-                qCDebug(CLASS_LC()) << "Worker class deleted";
-                delete m_workerThread;
-                m_workerThread = nullptr;
-                qCDebug(CLASS_LC()) << "Worker thread deleted";
-            } else {
-                delete m_worker;
-                m_worker = nullptr;
-                qCDebug(CLASS_LC()) << "Worker class deleted";
-                delete m_workerThread;
-                m_workerThread = nullptr;
-                qCDebug(CLASS_LC()) << "Worker thread deleted";
-            }
-        } else {
-            delete m_worker;
-            m_worker = nullptr;
-            qCDebug(CLASS_LC()) << "Worker class deleted";
+            m_workerThread->wait();
             delete m_workerThread;
             m_workerThread = nullptr;
-            qCDebug(CLASS_LC()) << "Worker thread deleted";
+            qCDebug(CLASS_LC()) << "WorkerThread was deleted";
         }
     }
+
+    qCDebug(CLASS_LC()) << "Processing done";
 }
 
 void MediaPlayerUtils::generateImages(const QString &url) {
@@ -195,9 +155,9 @@ MediaPlayerUtilsWorker::~MediaPlayerUtilsWorker() {
     qCDebug(CLASS_LC()) << "Worker destructor";
     if (m_manager) {
         delete m_manager;
+        qCDebug(CLASS_LC()) << "Worker destructor: Manager deleted.";
     }
     m_manager = nullptr;
-    qCDebug(CLASS_LC()) << "Worker destructor: Manager deleted.";
 }
 
 void MediaPlayerUtilsWorker::generateImages(const QString &url) {

--- a/components/media_player/sources/utils_mediaplayer.cpp
+++ b/components/media_player/sources/utils_mediaplayer.cpp
@@ -212,7 +212,7 @@ void MediaPlayerUtilsWorker::generateImagesReply() {
             ////////////////////////////////////////////////////////////////////
             /// CREATE LARGE BACKGROUND IMAGE
             ////////////////////////////////////////////////////////////////////
-            qCDebug(CLASS_LC()) << "Creating large image";
+            qCDebug(CLASS_LC()) << "Creating image";
             // resize image
             image.scaledToHeight(280, Qt::SmoothTransformation);
 
@@ -226,7 +226,7 @@ void MediaPlayerUtilsWorker::generateImagesReply() {
             painter.drawImage(image.rect(), noise);
             painter.end();
 
-            qCDebug(CLASS_LC()) << "Creating large image DONE";
+            qCDebug(CLASS_LC()) << "Creating image DONE";
 
             emit processingDone(m_pixelColor, image);
         }
@@ -234,10 +234,7 @@ void MediaPlayerUtilsWorker::generateImagesReply() {
         qCWarning(CLASS_LC) << "NETWORK REPLY ERROR" << m_reply->errorString();
         emit processingDone(QColor("black"), QImage());
     }
-    if (m_reply) {
-        m_reply->deleteLater();
-        m_reply = nullptr;
-    }
+    m_reply->deleteLater();
     qCDebug(CLASS_LC()) << "Network reply deleted";
 }
 

--- a/components/media_player/sources/utils_mediaplayer.cpp
+++ b/components/media_player/sources/utils_mediaplayer.cpp
@@ -24,6 +24,7 @@
 
 #include <QDebug>
 #include <QLoggingCategory>
+
 #include "../sources/config.h"
 
 static Q_LOGGING_CATEGORY(CLASS_LC, "mediaplayer utils");
@@ -275,15 +276,9 @@ QColor MediaPlayerUtilsWorker::dominantColor(const QImage &image) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// IMAGE PROVIDER
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-MediaPlayerUtilsImageProvider *MediaPlayerUtilsImageProvider::s_instance = nullptr;
-
 MediaPlayerUtilsImageProvider::MediaPlayerUtilsImageProvider() : QQuickImageProvider(QQuickImageProvider::Image) {
-    s_instance = this;
-
-    m_noImage = QImage(280, 280, QImage::Format_RGB888);
-    m_noImage.fill(Qt::black);
-    blockSignals(false);
+    m_noImage = QImage(280, 280, QImage::Format_ARGB32);
+    m_noImage.fill(qRgba(0, 0, 0, 0));
 }
 
 QImage MediaPlayerUtilsImageProvider::requestImage(const QString &id, QSize *size, const QSize &requestedSize) {

--- a/components/media_player/sources/utils_mediaplayer.cpp
+++ b/components/media_player/sources/utils_mediaplayer.cpp
@@ -58,7 +58,7 @@ MediaPlayerUtils::~MediaPlayerUtils() {
     if (m_workerThread != nullptr) {
         if (m_workerThread->isRunning()) {
             qCDebug(CLASS_LC()) << "Destructor: Worker thread is running";
-            m_workerThread->exit();
+            m_workerThread->quit();
             if (!m_workerThread->wait(5000)) {
                 qCDebug(CLASS_LC()) << "Destructor: Terminating worker thread";
                 m_workerThread->terminate();
@@ -140,7 +140,7 @@ void MediaPlayerUtils::onProcessingDone(const QColor &pixelColor, const QImage &
     if (m_workerThread != nullptr) {
         if (m_workerThread->isRunning()) {
             qCDebug(CLASS_LC()) << "Worker thread is running";
-            m_workerThread->exit();
+            m_workerThread->quit();
             if (!m_workerThread->wait(5000)) {
                 qCDebug(CLASS_LC()) << "Terminating worker thread";
                 m_workerThread->terminate();
@@ -187,18 +187,21 @@ void MediaPlayerUtils::generateImages(const QString &url) {
     }
 }
 
-MediaPlayerUtilsWorker::MediaPlayerUtilsWorker(QObject *parent) : QObject(parent) {}
+MediaPlayerUtilsWorker::MediaPlayerUtilsWorker(QObject *parent) : QObject(parent) {
+    m_manager = new QNetworkAccessManager();
+}
 
 MediaPlayerUtilsWorker::~MediaPlayerUtilsWorker() {
     qCDebug(CLASS_LC()) << "Worker destructor";
+    if (m_manager) {
+        delete m_manager;
+    }
     m_manager = nullptr;
     qCDebug(CLASS_LC()) << "Worker destructor: Manager deleted.";
 }
 
 void MediaPlayerUtilsWorker::generateImages(const QString &url) {
-    m_manager = new QNetworkAccessManager();
-    m_reply   = m_manager->get(QNetworkRequest(QUrl(url)));
-
+    m_reply = m_manager->get(QNetworkRequest(QUrl(url)));
     connect(m_reply, &QNetworkReply::finished, this, &MediaPlayerUtilsWorker::generateImagesReply);
 }
 

--- a/components/media_player/sources/utils_mediaplayer.cpp
+++ b/components/media_player/sources/utils_mediaplayer.cpp
@@ -24,11 +24,18 @@
 
 #include <QDebug>
 #include <QLoggingCategory>
+#include "../sources/config.h"
 
 static Q_LOGGING_CATEGORY(CLASS_LC, "mediaplayer utils");
 
 MediaPlayerUtils::MediaPlayerUtils(QObject *parent) : QObject(parent) {
-    m_imageProvider = MediaPlayerUtilsImageProvider::getInstance();
+    // ADD IMAGE PROVIDER
+    m_engine = Config::getInstance()->getAppEngine();
+
+    m_imageProviderId = QUuid::createUuid().toString().replace("{", "").replace("}", "");
+    m_imageProvider   = new MediaPlayerUtilsImageProvider();
+    m_engine->addImageProvider(m_imageProviderId, m_imageProvider);
+    qCDebug(CLASS_LC()) << "Image provider added:" << m_imageProviderId << m_imageProvider;
 
     m_startTimer = new QTimer(this);
     m_startTimer->setSingleShot(true);

--- a/components/media_player/sources/utils_mediaplayer.h
+++ b/components/media_player/sources/utils_mediaplayer.h
@@ -39,11 +39,9 @@ class MediaPlayerUtilsImageProvider : public QObject, public QQuickImageProvider
     Q_OBJECT
 
  public:
-    MediaPlayerUtilsImageProvider();
+    explicit MediaPlayerUtilsImageProvider();
 
     QImage requestImage(const QString& id, QSize* size, const QSize& requestedSize) override;
-
-    static MediaPlayerUtilsImageProvider* getInstance() { return s_instance; }
 
  public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
     void updateImage(const QImage& image);
@@ -54,8 +52,6 @@ class MediaPlayerUtilsImageProvider : public QObject, public QQuickImageProvider
  private:
     QImage m_image;
     QImage m_noImage;
-
-    static MediaPlayerUtilsImageProvider* s_instance;
 };
 
 class MediaPlayerUtilsWorker : public QObject {
@@ -87,7 +83,7 @@ class MediaPlayerUtils : public QObject {
 
     Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
     Q_PROPERTY(QString imageURL READ imageURL WRITE setImageURL)
-    Q_PROPERTY(QString imageProviderId READ imageProviderId CONSTANT);
+    Q_PROPERTY(QString imageProviderId READ imageProviderId CONSTANT)
     Q_PROPERTY(QColor pixelColor READ pixelColor NOTIFY pixelColorChanged)
 
     bool    enabled() { return m_enabled; }

--- a/components/media_player/sources/utils_mediaplayer.h
+++ b/components/media_player/sources/utils_mediaplayer.h
@@ -29,9 +29,11 @@
 #include <QNetworkReply>
 #include <QObject>
 #include <QPainter>
+#include <QQmlApplicationEngine>
 #include <QQuickImageProvider>
 #include <QThread>
 #include <QTimer>
+#include <QUuid>
 
 class MediaPlayerUtilsImageProvider : public QObject, public QQuickImageProvider {
     Q_OBJECT
@@ -85,10 +87,12 @@ class MediaPlayerUtils : public QObject {
 
     Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
     Q_PROPERTY(QString imageURL READ imageURL WRITE setImageURL)
+    Q_PROPERTY(QString imageProviderId READ imageProviderId CONSTANT);
     Q_PROPERTY(QColor pixelColor READ pixelColor NOTIFY pixelColorChanged)
 
     bool    enabled() { return m_enabled; }
     QString imageURL() { return m_imageURL; }
+    QString imageProviderId() { return m_imageProviderId; }
     QColor  pixelColor() { return m_pixelColor; }
 
     void setImageURL(QString url);
@@ -116,4 +120,7 @@ class MediaPlayerUtils : public QObject {
     QThread*                       m_workerThread = nullptr;
     MediaPlayerUtilsWorker*        m_worker       = nullptr;
     MediaPlayerUtilsImageProvider* m_imageProvider;
+    QString                        m_imageProviderId;
+
+    QQmlApplicationEngine* m_engine;
 };

--- a/components/media_player/sources/utils_mediaplayer.h
+++ b/components/media_player/sources/utils_mediaplayer.h
@@ -30,6 +30,7 @@
 #include <QObject>
 #include <QPainter>
 #include <QThread>
+#include <QTimer>
 
 class MediaPlayerUtilsWorker : public QObject {
     Q_OBJECT
@@ -91,6 +92,7 @@ class MediaPlayerUtils : public QObject {
     QString m_image;
     QString m_smallImage;
     QColor  m_pixelColor;
+    QTimer* m_startTimer;
 
     void generateImages(const QString& url);
 

--- a/components/media_player/sources/utils_mediaplayer.h
+++ b/components/media_player/sources/utils_mediaplayer.h
@@ -112,6 +112,7 @@ class MediaPlayerUtils : public QObject {
     QTimer* m_startTimer;
 
     void generateImages(const QString& url);
+    void deleteWorker();
 
     QThread*                       m_workerThread = nullptr;
     MediaPlayerUtilsWorker*        m_worker       = nullptr;

--- a/components/media_player/ui/Button.qml
+++ b/components/media_player/ui/Button.qml
@@ -38,6 +38,8 @@ Comp.ButtonBase {
     // override default settings
     title.anchors.verticalCenterOffset: obj && obj.source === "" ? 0 : -15
 
+    property alias mediaplayerUtils: mediaplayerUtils
+
     // include mediaplayer utils
     MediaPlayerUtils {
         id: mediaplayerUtils
@@ -49,7 +51,7 @@ Comp.ButtonBase {
 
         onImageChanged: {
             image.stopLoader();
-            image.url = "image://mediautilsprovider/image?id=" + counter;
+            counter = !counter;
         }
     }
 
@@ -85,7 +87,6 @@ Comp.ButtonBase {
     property bool counter: false
 
     onM_imageChanged: {
-        counter = !counter;
         mediaplayerUtils.imageURL = obj ? obj.mediaImage : ""
     }
 
@@ -94,7 +95,7 @@ Comp.ButtonBase {
         visible: mediaplayerButton.state == "closed" ? true : false
         width: 80; height: 80
         anchors { left: parent.left; leftMargin: 20; verticalCenter: parent.verticalCenter }
-        //        url: "image://mediautilsprovider/image?id=" + counter
+        url: "image://" + mediaplayerUtils.imageProviderId + "/image?id=" + counter
 
         layer.enabled: true
         layer.effect: OpacityMask {

--- a/components/media_player/ui/Button.qml
+++ b/components/media_player/ui/Button.qml
@@ -49,6 +49,7 @@ Comp.ButtonBase {
 
         onImageChanged: {
             image.stopLoader();
+            image.url = "image://mediautilsprovider/image?id=" + counter;
         }
     }
 
@@ -81,8 +82,10 @@ Comp.ButtonBase {
 
     // album art
     property string m_image: obj ? obj.mediaImage : ""
+    property bool counter: false
 
     onM_imageChanged: {
+        counter = !counter;
         mediaplayerUtils.imageURL = obj ? obj.mediaImage : ""
     }
 
@@ -91,7 +94,7 @@ Comp.ButtonBase {
         visible: mediaplayerButton.state == "closed" ? true : false
         width: 80; height: 80
         anchors { left: parent.left; leftMargin: 20; verticalCenter: parent.verticalCenter }
-        url: mediaplayerUtils.smallImage == "" ? "" : mediaplayerUtils.smallImage
+        //        url: "image://mediautilsprovider/image?id=" + counter
 
         layer.enabled: true
         layer.effect: OpacityMask {

--- a/components/media_player/ui/CardHome.qml
+++ b/components/media_player/ui/CardHome.qml
@@ -38,6 +38,8 @@ Rectangle {
         ColorAnimation { duration: 300 }
     }
 
+    property bool counter: false
+
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // STATES
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -135,6 +137,7 @@ Rectangle {
 
         onImageChanged: {
             albumArt.stopLoader();
+            counter = !counter;
         }
     }
 
@@ -184,7 +187,7 @@ Rectangle {
         id: albumArt
         width: 280; height: 280
         anchors { top: parent.top; topMargin: 118; horizontalCenter: parent.horizontalCenter }
-        url: mediaplayerUtils.image === "" ? "qrc:/images/mini-music-player/no_image.png" : mediaplayerUtils.image
+        url: "image://mediautilsprovider/image?id=" + counter
     }
 
     Text {

--- a/components/media_player/ui/CardHome.qml
+++ b/components/media_player/ui/CardHome.qml
@@ -114,6 +114,7 @@ Rectangle {
 
     Component.onCompleted: {
         cardHome.state = "open";
+        counter = !counter;
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -187,7 +188,7 @@ Rectangle {
         id: albumArt
         width: 280; height: 280
         anchors { top: parent.top; topMargin: 118; horizontalCenter: parent.horizontalCenter }
-        url: "image://mediautilsprovider/image?id=" + counter
+        url: "image://" + mediaplayerUtils.imageProviderId + "/image?id=" + counter
     }
 
     Text {

--- a/sources/config.h
+++ b/sources/config.h
@@ -137,6 +137,8 @@ class Config : public QObject, public ConfigInterface {
     QVariantMap  getAllEntities() override { return m_config["entities"].toMap(); }
     QVariantList getEntities(const QString& type) override { return getAllEntities().value(type).toList(); }
 
+    QQmlApplicationEngine* getAppEngine() { return m_engine; }
+
  public:
     explicit Config(QQmlApplicationEngine* engine, QString configFilePath, QString schemaFilePath, QString appPath);
     ~Config() override;

--- a/sources/entities/entities.cpp
+++ b/sources/entities/entities.cpp
@@ -188,7 +188,10 @@ void Entities::add(const QString &type, const QVariantMap &config, IntegrationIn
     if (entity == nullptr) {
         qCDebug(CLASS_LC) << "Illegal entity type : " << type;
     } else {
-        m_entities.insert(entity->entity_id(), entity);
+        if (!m_entities.contains(entity->entity_id())) {
+            m_entities.insert(entity->entity_id(), entity);
+            qCDebug(CLASS_LC) << "Entity added to entity registry:" << entity->entity_id();
+        }
     }
 }
 
@@ -197,7 +200,7 @@ void Entities::remove(const QString &entity_id) { m_entities.remove(entity_id); 
 void Entities::update(const QString &entity_id, const QVariantMap &attributes) {
     Entity *e = static_cast<Entity *>(m_entities.value(entity_id));
     if (e == nullptr)
-        qCDebug(CLASS_LC) << "Entity not found : " << entity_id;
+        qCDebug(CLASS_LC) << "Entity not found:" << entity_id;
     else
         e->update(attributes);
 }
@@ -209,7 +212,7 @@ void Entities::addMediaplayersPlaying(const QString &entity_id) {
 
     // check if there is a timer active to remove the media player
     if (m_mediaplayersTimers.contains(entity_id)) {
-        qCDebug(CLASS_LC) << "There is a timer for:" << entity_id;
+        qCDebug(CLASS_LC) << "Mediaplayers playing: There is a timer for:" << entity_id;
         QTimer *timer = m_mediaplayersTimers.value(entity_id);
         if (timer) {
             timer->stop();
@@ -217,18 +220,18 @@ void Entities::addMediaplayersPlaying(const QString &entity_id) {
             m_mediaplayersTimers.remove(entity_id);
             timer->deleteLater();
         }
-        qCDebug(CLASS_LC) << "Removing timer";
+        qCDebug(CLASS_LC) << "Mediaplayers playing: Removing timer";
     }
 
     if (!m_mediaplayersPlaying.contains(entity_id)) {
-        qCDebug(CLASS_LC) << "Getting entity object" << entity_id;
+        qCDebug(CLASS_LC) << "Mediaplayers playing: Getting entity object" << entity_id;
         QObject *o = get(entity_id);
-        qCDebug(CLASS_LC) << "Object parent:" << o->parent();
+        qCDebug(CLASS_LC) << "Mediaplayers playing: Object parent:" << o->parent();
         //        o->setParent(this);
 
-        qCDebug(CLASS_LC) << "Object is not in the list, adding to list" << entity_id;
+        qCDebug(CLASS_LC) << "Mediaplayers playing: Object is not in the list, adding to list" << entity_id;
         m_mediaplayersPlaying.insert(entity_id, o);
-        qCDebug(CLASS_LC) << "Emitting mediaplayersPlayingChanged";
+        qCDebug(CLASS_LC) << "Mediaplayers playing: Emitting mediaplayersPlayingChanged";
         emit mediaplayersPlayingChanged();
     }
 }
@@ -237,60 +240,58 @@ void Entities::removeMediaplayersPlaying(const QString &entity_id, const bool &n
     QMutexLocker locker(&m_mutex);
 
     if (m_mediaplayersPlaying.contains(entity_id)) {
-        qCDebug(CLASS_LC) << "There is an object playing list" << entity_id;
+        qCDebug(CLASS_LC) << "Mediaplayers playing: There is an object playing list" << entity_id;
         if (now) {
-            qCDebug(CLASS_LC) << "Removing object" << entity_id;
+            qCDebug(CLASS_LC) << "Mediaplayers playing: Removing object" << entity_id;
             m_mediaplayersPlaying.remove(entity_id);
 
             if (m_mediaplayersTimers.contains(entity_id)) {
-                qCDebug(CLASS_LC) << "Removing timer" << entity_id;
+                qCDebug(CLASS_LC) << "Mediaplayers playing: Removing timer" << entity_id;
                 m_mediaplayersTimers.remove(entity_id);
             }
 
-            qCDebug(CLASS_LC) << "Emitting mediaplayersPlayingChanged";
+            qCDebug(CLASS_LC) << "Mediaplayers playing: Emitting mediaplayersPlayingChanged";
             emit mediaplayersPlayingChanged();
 
         } else {
             // use a timer to remove the entity with a delay
             if (!m_mediaplayersTimers.contains(entity_id)) {
-                qCDebug(CLASS_LC) << "No timer found for object" << entity_id;
+                qCDebug(CLASS_LC) << "Mediaplayers playing: No timer found for object" << entity_id;
                 QTimer *timer = new QTimer();
                 timer->setSingleShot(true);
 
                 QObject *context = new QObject();
 
-                qCDebug(CLASS_LC) << "Connecting signals" << entity_id;
+                qCDebug(CLASS_LC) << "Mediaplayers playing: Connecting signals" << entity_id;
                 connect(timer, &QTimer::timeout, context, [=]() {
-                    qCDebug(CLASS_LC) << "Timer timeout" << entity_id;
+                    qCDebug(CLASS_LC) << "Mediaplayers playing: Timer timeout" << entity_id;
                     if (m_mediaplayersPlaying.contains(entity_id)) {
-                        qCDebug(CLASS_LC) << "Removing object" << entity_id;
+                        qCDebug(CLASS_LC) << "Mediaplayers playing: Removing object" << entity_id;
                         m_mediaplayersPlaying.remove(entity_id);
                     }
 
                     if (m_mediaplayersTimers.contains(entity_id)) {
-                        qCDebug(CLASS_LC) << "Removing timer" << entity_id;
+                        qCDebug(CLASS_LC) << "Mediaplayers playing: Removing timer" << entity_id;
                         m_mediaplayersTimers.remove(entity_id);
                     }
 
-                    qCDebug(CLASS_LC) << "Emitting mediaplayersPlayingChanged";
+                    qCDebug(CLASS_LC) << "Mediaplayers playing: Emitting mediaplayersPlayingChanged";
                     emit mediaplayersPlayingChanged();
-                    qCDebug(CLASS_LC) << "Context deleteLater";
+                    qCDebug(CLASS_LC) << "Mediaplayers playing: Context deleteLater";
                     context->deleteLater();
-                    qCDebug(CLASS_LC) << "Timer deleteLater";
+                    qCDebug(CLASS_LC) << "Mediaplayers playing: Timer deleteLater";
                     timer->deleteLater();
                 });
 
-                qCDebug(CLASS_LC) << "Starting timer" << entity_id;
+                qCDebug(CLASS_LC) << "Mediaplayers playing: Starting timer" << entity_id;
                 timer->start(120000);
 
-                qCDebug(CLASS_LC) << "Inserting timer to the list" << entity_id;
+                qCDebug(CLASS_LC) << "Mediaplayers playing: Inserting timer to the list" << entity_id;
                 m_mediaplayersTimers.insert(entity_id, timer);
             }
         }
     }
 }
-
-// void Entities::addLoadedEntity(const QString &entity) { m_loaded_entities.append(entity); }
 
 QString Entities::getSupportedEntityTranslation(const QString &type) {
     QString translation;

--- a/sources/entities/entities.cpp
+++ b/sources/entities/entities.cpp
@@ -82,6 +82,14 @@ void Entities::load() {
         }
     }
     emit entitiesLoaded();
+
+    // when all entities are loaded, connect the integrations
+    QList<QObject *> integrations = Integrations::getInstance()->list();
+    for (int i = 0; i < integrations.count(); i++) {
+        QObject *             obj = integrations[i];
+        IntegrationInterface *ii  = qobject_cast<IntegrationInterface *>(obj);
+        ii->connect();
+    }
 }
 
 QList<EntityInterface *> Entities::getByType(const QString &type) {

--- a/sources/hardware/linux/arm/mcp23017_interrupt.cpp
+++ b/sources/hardware/linux/arm/mcp23017_interrupt.cpp
@@ -106,11 +106,6 @@ bool Mcp23017InterruptHandler::setupGPIO() {
 }
 
 void Mcp23017InterruptHandler::interruptHandler() {
-    QFile file(m_gpioValueDevice);
-    if (!file.open(QIODevice::ReadOnly)) {
-        qCCritical(CLASS_LC) << "Error opening:" << m_gpioValueDevice;
-        return;
-    }
     int  e = mcp.readInterrupt();
     emit interruptEvent(e);
 }

--- a/sources/integrations/integrations.cpp
+++ b/sources/integrations/integrations.cpp
@@ -145,10 +145,6 @@ void Integrations::onCreateDone(QMap<QObject*, QVariant> map) {
     // add the integrations to the integration database
     for (QMap<QObject*, QVariant>::const_iterator iter = map.begin(); iter != map.end(); ++iter) {
         add(iter.value().toMap(), iter.key(), iter.value().toMap().value("type").toString());
-        IntegrationInterface* ii = qobject_cast<IntegrationInterface*>(iter.key());
-        if (ii) {
-            ii->connect();
-        }
     }
     m_integrationsLoaded++;
 

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -247,6 +247,11 @@ int main(int argc, char* argv[]) {
     // set rending of text
     QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
 
+    // ADD IMAGE PROVIDER
+    QScopedPointer<MediaPlayerUtilsImageProvider> mediaPlayerUtilsImageProvider(new MediaPlayerUtilsImageProvider());
+    engine.rootContext()->setContextProperty("mediautilsprovider", mediaPlayerUtilsImageProvider.data());
+    engine.addImageProvider("mediautilsprovider", mediaPlayerUtilsImageProvider.data());
+
     engine.addImportPath("qrc:/");
 
     engine.load(QUrl(QStringLiteral("qrc:/main.qml")));

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -247,11 +247,6 @@ int main(int argc, char* argv[]) {
     // set rending of text
     QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
 
-    // ADD IMAGE PROVIDER
-    QScopedPointer<MediaPlayerUtilsImageProvider> mediaPlayerUtilsImageProvider(new MediaPlayerUtilsImageProvider());
-    engine.rootContext()->setContextProperty("mediautilsprovider", mediaPlayerUtilsImageProvider.data());
-    engine.addImageProvider("mediautilsprovider", mediaPlayerUtilsImageProvider.data());
-
     engine.addImportPath("qrc:/");
 
     engine.load(QUrl(QStringLiteral("qrc:/main.qml")));


### PR DESCRIPTION
Before we were using a base64 encoded QString to transfer images from C++ to QML. This was painfully slow and resource heavy due to lot of copying.

This new method is creating an ImageProvider to send the images to QML. As it's Qt's native solution, it's much faster. The heavy duty downloading/resizing is done in a thread to avoid blocking the UI.