### PR TITLE
QML enum handling and UnitSystem fixes

### DIFF
--- a/basic_ui/settings/Wifi.qml
+++ b/basic_ui/settings/Wifi.qml
@@ -159,11 +159,11 @@ Item {
                 Text {
                     color: Style.color.text
                     text: {
-                        if (wifi.wifiStatus.signalStrength == SignalStrengthEnum.WEAK || wifi.wifiStatus.signalStrength == SignalStrengthEnum.NONE)
+                        if (wifi.wifiStatus.signalStrength === SignalStrength.WEAK || wifi.wifiStatus.signalStrength === SignalStrength.NONE)
                             return Style.icon.wifi_1
-                        else if (wifi.wifiStatus.signalStrength == SignalStrengthEnum.OK)
+                        else if (wifi.wifiStatus.signalStrength === SignalStrength.OK)
                             return Style.icon.wifi_2
-                        else if (wifi.wifiStatus.signalStrength == SignalStrengthEnum.GOOD || wifi.wifiStatus.signalStrength == SignalStrengthEnum.EXCELLENT)
+                        else if (wifi.wifiStatus.signalStrength === SignalStrength.GOOD || wifi.wifiStatus.signalStrength === SignalStrength.EXCELLENT)
                             return Style.icon.wifi_3
                         else return ""
                     }
@@ -238,11 +238,11 @@ Item {
                         Text {
                             color: Style.color.text
                             text: {
-                                if (wifi.networkScanResult[index].signalStrength == SignalStrengthEnum.WEAK || wifi.networkScanResult[index].signalStrength == SignalStrengthEnum.NONE)
+                                if (wifi.networkScanResult[index].signalStrength === SignalStrength.WEAK || wifi.networkScanResult[index].signalStrength === SignalStrength.NONE)
                                     return Style.icon.wifi_1
-                                else if (wifi.networkScanResult[index].signalStrength == SignalStrengthEnum.OK)
+                                else if (wifi.networkScanResult[index].signalStrength === SignalStrength.OK)
                                     return Style.icon.wifi_2
-                                else if (wifi.networkScanResult[index].signalStrength == SignalStrengthEnum.GOOD || wifi.networkScanResult[index].signalStrength == SignalStrengthEnum.EXCELLENT)
+                                else if (wifi.networkScanResult[index].signalStrength === SignalStrength.GOOD || wifi.networkScanResult[index].signalStrength === SignalStrength.EXCELLENT)
                                     return Style.icon.wifi_3
                                 else return ""
                             }

--- a/basic_ui/settings/Wifi.qml
+++ b/basic_ui/settings/Wifi.qml
@@ -159,13 +159,15 @@ Item {
                 Text {
                     color: Style.color.text
                     text: {
-                        if (wifi.wifiStatus.signalStrength === SignalStrength.WEAK || wifi.wifiStatus.signalStrength === SignalStrength.NONE)
-                            return Style.icon.wifi_1
-                        else if (wifi.wifiStatus.signalStrength === SignalStrength.OK)
-                            return Style.icon.wifi_2
-                        else if (wifi.wifiStatus.signalStrength === SignalStrength.GOOD || wifi.wifiStatus.signalStrength === SignalStrength.EXCELLENT)
-                            return Style.icon.wifi_3
-                        else return ""
+                        switch(wifi.wifiStatus.signalStrength) {
+                        case SignalStrength.EXCELLENT:
+                        case SignalStrength.GOOD:
+                            return Style.icon.wifi_3;
+                        case SignalStrength.OK:
+                            return Style.icon.wifi_2;
+                        default:
+                            return Style.icon.wifi_1;
+                        }
                     }
                     renderType: Text.NativeRendering
                     width: 70; height: 70
@@ -238,13 +240,15 @@ Item {
                         Text {
                             color: Style.color.text
                             text: {
-                                if (wifi.networkScanResult[index].signalStrength === SignalStrength.WEAK || wifi.networkScanResult[index].signalStrength === SignalStrength.NONE)
-                                    return Style.icon.wifi_1
-                                else if (wifi.networkScanResult[index].signalStrength === SignalStrength.OK)
-                                    return Style.icon.wifi_2
-                                else if (wifi.networkScanResult[index].signalStrength === SignalStrength.GOOD || wifi.networkScanResult[index].signalStrength === SignalStrength.EXCELLENT)
-                                    return Style.icon.wifi_3
-                                else return ""
+                                switch(wifi.networkScanResult[index].signalStrength) {
+                                case SignalStrength.EXCELLENT:
+                                case SignalStrength.GOOD:
+                                    return Style.icon.wifi_3;
+                                case SignalStrength.OK:
+                                    return Style.icon.wifi_2;
+                                default:
+                                    return Style.icon.wifi_1;
+                                }
                             }
                             renderType: Text.NativeRendering
                             width: 70; height: 70

--- a/config-schema.json
+++ b/config-schema.json
@@ -936,6 +936,16 @@
             }
           }
         },
+        "unit": {
+          "$id": "#/properties/settings/properties/unit",
+          "type": "string",
+          "enum": [
+            "METRIC",
+            "IMPERIAL"
+          ],
+          "title": "Unit system",
+          "default": "METRIC"
+        },
         "wifitime": {
           "$id": "#/properties/settings/properties/wifitime",
           "type": "integer",

--- a/config.json
+++ b/config.json
@@ -26,6 +26,7 @@
             "appUpdateScript": "/opt/yio/scripts/app-update.sh",
             "systemUpdateScript": "/opt/yio/scripts/TODO.sh"
         },
+        "unit": "METRIC",
         "wifitime": 1740
     },
     "ui_config": {

--- a/dependencies.cfg
+++ b/dependencies.cfg
@@ -3,4 +3,4 @@
 #   name: dependency name
 #   separator: colon + optional white space
 #   version: git branch or tag
-integrations.library: v0.4.3
+integrations.library: qml-enums

--- a/dependencies.cfg
+++ b/dependencies.cfg
@@ -3,4 +3,4 @@
 #   name: dependency name
 #   separator: colon + optional white space
 #   version: git branch or tag
-integrations.library: qml-enums
+integrations.library: v0.5.0

--- a/setup/SetupStep3.qml
+++ b/setup/SetupStep3.qml
@@ -122,11 +122,11 @@ Item {
                 Text {
                     color: Style.color.text
                     text: {
-                        if (wifi.networkScanResult[index].signalStrength == SignalStrengthEnum.WEAK || wifi.networkScanResult[index].signalStrength == SignalStrengthEnum.NONE)
+                        if (wifi.networkScanResult[index].signalStrength === SignalStrength.WEAK || wifi.networkScanResult[index].signalStrength === SignalStrength.NONE)
                             return Style.icon.wifi_1
-                        else if (wifi.networkScanResult[index].signalStrength == SignalStrengthEnum.OK)
+                        else if (wifi.networkScanResult[index].signalStrength === SignalStrength.OK)
                             return Style.icon.wifi_2
-                        else if (wifi.networkScanResult[index].signalStrength == SignalStrengthEnum.GOOD || wifi.networkScanResult[index].signalStrength == SignalStrengthEnum.EXCELLENT)
+                        else if (wifi.networkScanResult[index].signalStrength === SignalStrength.GOOD || wifi.networkScanResult[index].signalStrength === SignalStrength.EXCELLENT)
                             return Style.icon.wifi_3
                         else return ""
                     }

--- a/setup/SetupStep3.qml
+++ b/setup/SetupStep3.qml
@@ -122,13 +122,15 @@ Item {
                 Text {
                     color: Style.color.text
                     text: {
-                        if (wifi.networkScanResult[index].signalStrength === SignalStrength.WEAK || wifi.networkScanResult[index].signalStrength === SignalStrength.NONE)
-                            return Style.icon.wifi_1
-                        else if (wifi.networkScanResult[index].signalStrength === SignalStrength.OK)
-                            return Style.icon.wifi_2
-                        else if (wifi.networkScanResult[index].signalStrength === SignalStrength.GOOD || wifi.networkScanResult[index].signalStrength === SignalStrength.EXCELLENT)
-                            return Style.icon.wifi_3
-                        else return ""
+                        switch(wifi.networkScanResult[index].signalStrength) {
+                        case SignalStrength.EXCELLENT:
+                        case SignalStrength.GOOD:
+                            return Style.icon.wifi_3;
+                        case SignalStrength.OK:
+                            return Style.icon.wifi_2;
+                        default:
+                            return Style.icon.wifi_1;
+                        }
                     }
                     renderType: Text.NativeRendering
                     width: 70; height: 70

--- a/setup/SetupStep4Other.qml
+++ b/setup/SetupStep4Other.qml
@@ -48,9 +48,9 @@ Rectangle {
 
         let security;
         if (passwordField.text == "") {
-            security = WifiSecurityEnum.NONE_OPEN;
+            security = WifiSecurity.NONE_OPEN;
         } else {
-            security = WifiSecurityEnum.DEFAULT;
+            security = WifiSecurity.DEFAULT;
         }
 
         wifi.join(name, passwordField.text, security);

--- a/sources/bluetooth.cpp
+++ b/sources/bluetooth.cpp
@@ -30,14 +30,14 @@
 static Q_LOGGING_CATEGORY(CLASS_LC, "bluetooth");
 
 BluetoothControl::BluetoothControl(QObject *parent) : QObject(parent) {
-    qCritical(CLASS_LC) << "Bluetooth starting";
+    qCInfo(CLASS_LC) << "Bluetooth starting";
 
     // if there is a bluetooth device, let's set up some things
     if (m_localDevice.isValid()) {
         qCDebug(CLASS_LC) << "Bluetooth init OK";
 
     } else {
-        qCritical(CLASS_LC) << "Bluetooth device was not found.";
+        qCCritical(CLASS_LC) << "Bluetooth device was not found.";
         Notifications::getInstance()->add(true, tr("Bluetooth device was not found."));
     }
 }

--- a/sources/config.cpp
+++ b/sources/config.cpp
@@ -28,39 +28,30 @@
 
 static Q_LOGGING_CATEGORY(CLASS_LC, "config");
 
-const QString Config::KEY_ID                 = CFG_KEY_ID;
-const QString Config::KEY_FRIENDLYNAME       = CFG_KEY_FRIENDLYNAME;
-const QString Config::KEY_ENTITY_ID          = CFG_KEY_ENTITY_ID;
-const QString Config::KEY_AREA               = CFG_KEY_AREA;
-const QString Config::KEY_INTEGRATION        = CFG_KEY_INTEGRATION;
+const QString Config::KEY_ID = CFG_KEY_ID;
+const QString Config::KEY_FRIENDLYNAME = CFG_KEY_FRIENDLYNAME;
+const QString Config::KEY_ENTITY_ID = CFG_KEY_ENTITY_ID;
+const QString Config::KEY_AREA = CFG_KEY_AREA;
+const QString Config::KEY_INTEGRATION = CFG_KEY_INTEGRATION;
 const QString Config::KEY_SUPPORTED_FEATURES = CFG_KEY_SUPPORTED_FEATURES;
-const QString Config::KEY_TYPE               = CFG_KEY_TYPE;
-const QString Config::KEY_MDNS               = CFG_KEY_MDNS;
-const QString Config::KEY_WORKERTHREAD       = CFG_KEY_WORKERTHREAD;
-const QString Config::OBJ_DATA               = CFG_OBJ_DATA;
+const QString Config::KEY_TYPE = CFG_KEY_TYPE;
+const QString Config::KEY_MDNS = CFG_KEY_MDNS;
+const QString Config::KEY_WORKERTHREAD = CFG_KEY_WORKERTHREAD;
+const QString Config::OBJ_DATA = CFG_OBJ_DATA;
 
 Config *Config::s_instance = nullptr;
 
 ConfigInterface::~ConfigInterface() {}
 
 Config::Config(QQmlApplicationEngine *engine, QString configFilePath, QString schemaFilePath, QString appPath)
-    : m_engine(engine), m_error("") {
+    : m_engine(engine), m_jsf(configFilePath, schemaFilePath), m_error("") {
     Q_ASSERT(engine);
-
-    m_jsf = new JsonFile();
-    m_jsf->setSchemaPath(schemaFilePath);
-
-    m_tf = new JsonFile();
 
     s_instance = this;
 
-    // load the config file
-    readConfig(configFilePath);
-
     // load translations file
-    QString translationsPath = appPath.append(QString("/translations.json"));
-    m_tf->setName(translationsPath);
-    m_languages = m_tf->read().toList();
+    JsonFile translationCfg(appPath.append(QString("/translations.json")), "");
+    m_languages = translationCfg.read().toList();
 }
 
 Config::~Config() { s_instance = nullptr; }
@@ -83,7 +74,7 @@ void Config::setFavorite(const QString &entityId, bool value) {
 
 void Config::setConfig(const QVariantMap &config) {
     m_error.clear();
-    if (!m_jsf->validate(QJsonDocument::fromVariant(config), m_error)) {
+    if (!m_jsf.validate(QJsonDocument::fromVariant(config), m_error)) {
         return;
     }
 
@@ -93,76 +84,63 @@ void Config::setConfig(const QVariantMap &config) {
     writeConfig();
 }
 
-bool Config::readConfig(const QString &filePath) {
+bool Config::readConfig() {
     // load the config.json file from the filesystem
-    m_jsf->setName(filePath);
-    m_config = m_jsf->read().toMap();
-    m_error  = m_jsf->error();
+    m_config = m_jsf.read().toMap();
+    m_error = m_jsf.error();
     syncConfigToCache();
     emit configChanged();
 
-    return m_jsf->isValid();
+    return m_jsf.isValid();
 }
 
 bool Config::writeConfig() {
     syncCacheToConfig();
-    bool result = m_jsf->write(m_config);
-    m_error     = m_jsf->error();
-    qCCritical(CLASS_LC()) << "Write to config file success:" << result;
+    bool result = m_jsf.write(m_config);
+    m_error = m_jsf.error();
+    if (!result) {
+        emit configWriteError(m_error);
+    }
     return result;
 }
 
 void Config::setSettings(const QVariantMap &config) {
     m_cacheSettings = config;
-    if (!writeConfig()) {
-        // this is a Q_PROPERTY write method: can't return false!
-        emit configWriteError(m_error);
-    }
+    writeConfig();
     emit settingsChanged();
 }
 
 void Config::setProfiles(const QVariantMap &config) {
     m_cacheUIProfiles = config;
-    m_cacheUIProfile  = m_cacheUIProfiles[m_cacheProfileId].toMap();
-    if (writeConfig()) {
-        emit configWriteError(m_error);
-    }
+    m_cacheUIProfile = m_cacheUIProfiles[m_cacheProfileId].toMap();
+    writeConfig();
     emit profilesChanged();
 }
 
 void Config::setUIConfig(const QVariantMap &config) {
     m_cacheUIConfig = config;
-    if (writeConfig()) {
-        // this is a Q_PROPERTY write method: can't return false!
-        emit configWriteError(m_error);
-    }
+    writeConfig();
     emit uiConfigChanged();
 }
 
 void Config::setPages(const QVariantMap &config) {
     m_cacheUIPages = config;
-    if (writeConfig()) {
-        emit configWriteError(m_error);
-    }
+    writeConfig();
     emit pagesChanged();
 }
 
 void Config::setGroups(const QVariantMap &config) {
     m_cacheUIGroups = config;
-    if (writeConfig()) {
-        emit configWriteError(m_error);
-    }
+    writeConfig();
     emit groupsChanged();
 }
 
-void Config::setUnitSystem(UnitSystem value) {
+void Config::setUnitSystem(UnitSystem::Enum value) {
     if (m_cacheUnitSystem != value) {
         m_cacheUnitSystem = value;
         emit unitSystemChanged();
     }
-    if (writeConfig()) {
-        emit configWriteError(m_error);
-    }
+    writeConfig();
 }
 
 QObject *Config::getQMLObject(QList<QObject *> nodes, const QString &name) {
@@ -182,14 +160,11 @@ QObject *Config::getQMLObject(QList<QObject *> nodes, const QString &name) {
 QObject *Config::getQMLObject(const QString &name) { return getQMLObject(m_engine->rootObjects(), name); }
 
 void Config::setProfileId(QString id) {
-    qCDebug(CLASS_LC()) << "Profile id changing to:" << id << "from:" << m_cacheProfileId;
+    qCDebug(CLASS_LC) << "Profile id changing to:" << id << "from:" << m_cacheProfileId;
     m_cacheProfileId = id;
     m_cacheUIProfile = m_cacheUIProfiles[m_cacheProfileId].toMap();
 
-    if (!writeConfig()) {
-        // this is a Q_PROPERTY write method: can't return false!
-        emit configWriteError(m_error);
-    }
+    writeConfig();
     emit profileIdChanged();
 }
 
@@ -197,14 +172,14 @@ void Config::syncConfigToCache() {
     m_cacheSettings = m_config["settings"].toMap();
     m_cacheUIConfig = m_config["ui_config"].toMap();
 
-    m_cacheProfileId  = m_cacheUIConfig["selected_profile"].toString();
+    m_cacheProfileId = m_cacheUIConfig["selected_profile"].toString();
     m_cacheUIProfiles = m_cacheUIConfig["profiles"].toMap();
-    m_cacheUIPages    = m_cacheUIConfig["pages"].toMap();
-    m_cacheUIGroups   = m_cacheUIConfig["groups"].toMap();
+    m_cacheUIPages = m_cacheUIConfig["pages"].toMap();
+    m_cacheUIGroups = m_cacheUIConfig["groups"].toMap();
 
     m_cacheUIProfile = m_cacheUIProfiles[m_cacheProfileId].toMap();
 
-    //    m_cacheUnitSystem = static_cast<UnitSystem>(m_cacheSettings["unit"].toInt());
+    m_cacheUnitSystem = stringToEnum<UnitSystem::Enum>(m_cacheSettings["unit"], UnitSystem::METRIC);
 }
 
 void Config::syncCacheToConfig() {
@@ -213,7 +188,7 @@ void Config::syncCacheToConfig() {
     m_cacheUIConfig.insert("pages", m_cacheUIPages);
     m_cacheUIConfig.insert("groups", m_cacheUIGroups);
 
-    //    m_cacheSettings.insert("unit", static_cast<int>(m_cacheUnitSystem));
+    m_cacheSettings.insert("unit", enumToString(m_cacheUnitSystem));
 
     m_config.insert("settings", m_cacheSettings);
     m_config.insert("ui_config", m_cacheUIConfig);

--- a/sources/config.h
+++ b/sources/config.h
@@ -30,6 +30,7 @@
 
 #include "jsonfile.h"
 #include "yio-interface/configinterface.h"
+#include "yio-interface/unitsystem.h"
 
 class Config : public QObject, public ConfigInterface {
     Q_OBJECT
@@ -45,7 +46,7 @@ class Config : public QObject, public ConfigInterface {
     Q_PROPERTY(QVariantMap ui_config READ getUIConfig WRITE setUIConfig NOTIFY uiConfigChanged)
     Q_PROPERTY(QVariantMap pages READ getPages NOTIFY pagesChanged)
     Q_PROPERTY(QVariantMap groups READ getGroups NOTIFY groupsChanged)
-    Q_PROPERTY(UnitSystem unitSystem READ getUnitSystem WRITE setUnitSystem NOTIFY unitSystemChanged)
+    Q_PROPERTY(UnitSystem::Enum unitSystem READ getUnitSystem WRITE setUnitSystem NOTIFY unitSystemChanged)
 
  public:
     // Common configuration keys. Initialized in config.cpp
@@ -60,8 +61,6 @@ class Config : public QObject, public ConfigInterface {
     static const QString KEY_MDNS;
     static const QString KEY_WORKERTHREAD;
     static const QString OBJ_DATA;
-
-    Q_ENUM(UnitSystem)
 
     // valid
     bool isValid() const { return m_error.isEmpty(); }
@@ -101,8 +100,8 @@ class Config : public QObject, public ConfigInterface {
     void        setGroups(const QVariantMap& config);
 
     // unit system
-    UnitSystem getUnitSystem() override { return m_cacheUnitSystem; }
-    void       setUnitSystem(UnitSystem value);
+    UnitSystem::Enum getUnitSystem() override { return m_cacheUnitSystem; }
+    void             setUnitSystem(UnitSystem::Enum value);
 
     // languages
     QVariantList getLanguages() { return m_languages; }
@@ -122,8 +121,12 @@ class Config : public QObject, public ConfigInterface {
     // set favorite entity
     void setFavorite(const QString& entityId, bool value);
 
-    // read and write configuration to file
-    bool readConfig(const QString& filePath);
+    // read configuration to file
+    bool readConfig();
+    /**
+     * @brief Persists the configuration. In case of an error, configWriteError is emitted.
+     * @return true if configuration could be successfully written
+     */
     bool writeConfig();
 
     // get a QML object, you need to have objectName property of the QML object set to be able to use this
@@ -159,26 +162,40 @@ class Config : public QObject, public ConfigInterface {
     void syncConfigToCache();
     void syncCacheToConfig();
 
+    template <class EnumClass>
+    QString enumToString(const EnumClass& enumKey) const {
+        const auto metaEnum = QMetaEnum::fromType<EnumClass>();
+        return metaEnum.valueToKey(static_cast<int>(enumKey));
+    }
+
+    template <class EnumClass>
+    EnumClass stringToEnum(const QVariant& enumString, const EnumClass& defaultValue) const {
+        const auto metaEnum = QMetaEnum::fromType<EnumClass>();
+        bool ok;
+        const auto value = metaEnum.keyToValue(enumString.toString().toUtf8(), &ok);
+        return ok ? static_cast<EnumClass>(value) : defaultValue;
+    }
+
+ private:
     static Config*         s_instance;
     QQmlApplicationEngine* m_engine;
 
+    // loaded configuration values
     QVariantMap  m_config;
     QVariantList m_languages;
 
-    JsonFile* m_jsf;
-    QString   m_error;
-
-    JsonFile* m_tf;
+    // json configuration file
+    JsonFile m_jsf;
+    // last read or write error message
+    QString m_error;
 
     // Caches to improve performance
-    QString     m_cacheProfileId;
-    QVariantMap m_cacheSettings;
-    QVariantMap m_cacheUIConfig;
-    QVariantMap m_cacheUIProfile;  // of selected Profile
-    QVariantMap m_cacheUIProfiles;
-    QVariantMap m_cacheUIPages;
-    QVariantMap m_cacheUIGroups;
-    UnitSystem  m_cacheUnitSystem = METRIC;
+    QString          m_cacheProfileId;
+    QVariantMap      m_cacheSettings;
+    QVariantMap      m_cacheUIConfig;
+    QVariantMap      m_cacheUIProfile;  // of selected Profile
+    QVariantMap      m_cacheUIProfiles;
+    QVariantMap      m_cacheUIPages;
+    QVariantMap      m_cacheUIGroups;
+    UnitSystem::Enum m_cacheUnitSystem = UnitSystem::METRIC;
 };
-
-typedef Config::UnitSystem UnitSystem;

--- a/sources/entities/climate.cpp
+++ b/sources/entities/climate.cpp
@@ -46,35 +46,35 @@ bool Climate::updateAttrByIndex(int attrIndex, const QVariant &value) {
         case ClimateDef::TEMPERATURE:
             if (m_temperature != value.toDouble()) {
                 m_temperature = value.toDouble();
-                chg           = true;
+                chg = true;
                 emit temperatureChanged();
             }
             break;
         case ClimateDef::TARGET_TEMPERATURE:
             if (m_targetTemperature != value.toDouble()) {
                 m_targetTemperature = value.toDouble();
-                chg                 = true;
+                chg = true;
                 emit targetTemperatureChanged();
             }
             break;
         case ClimateDef::TEMPERATURE_UNIT:
             if (m_temperatureUnit != value.toString()) {
                 m_temperatureUnit = value.toString();
-                chg               = true;
+                chg = true;
                 emit temperatureUnitChanged();
             }
             break;
         case ClimateDef::TEMPERATURE_MAX:
             if (m_temperatureMax != value.toDouble()) {
                 m_temperatureMax = value.toDouble();
-                chg              = true;
+                chg = true;
                 emit temperatureMaxChanged();
             }
             break;
         case ClimateDef::TEMPERATURE_MIN:
             if (m_temperatureMin != value.toDouble()) {
                 m_temperatureMin = value.toDouble();
-                chg              = true;
+                chg = true;
                 emit temperatureMinChanged();
             }
             break;
@@ -104,27 +104,27 @@ Climate::Climate(const QVariantMap &config, IntegrationInterface *integrationObj
     static QMetaEnum metaEnumState;
 
     if (!metaEnumAttr.isValid()) {
-        int index        = ClimateDef::staticMetaObject.indexOfEnumerator("Attributes");
-        metaEnumAttr     = ClimateDef::staticMetaObject.enumerator(index);
-        index            = ClimateDef::staticMetaObject.indexOfEnumerator("States");
-        metaEnumState    = ClimateDef::staticMetaObject.enumerator(index);
-        index            = ClimateDef::staticMetaObject.indexOfEnumerator("Features");
+        int index = ClimateDef::staticMetaObject.indexOfEnumerator("Attributes");
+        metaEnumAttr = ClimateDef::staticMetaObject.enumerator(index);
+        index = ClimateDef::staticMetaObject.indexOfEnumerator("States");
+        metaEnumState = ClimateDef::staticMetaObject.enumerator(index);
+        index = ClimateDef::staticMetaObject.indexOfEnumerator("Features");
         metaEnumFeatures = ClimateDef::staticMetaObject.enumerator(index);
-        index            = ClimateDef::staticMetaObject.indexOfEnumerator("Commands");
+        index = ClimateDef::staticMetaObject.indexOfEnumerator("Commands");
         metaEnumCommands = ClimateDef::staticMetaObject.enumerator(index);
         qmlRegisterUncreatableType<ClimateDef>("Entity.Climate", 1, 0, "Climate",
                                                "Not creatable as it is an enum type.");
     }
-    m_enumAttr          = &metaEnumAttr;
-    m_enumFeatures      = &metaEnumFeatures;
-    m_enumCommands      = &metaEnumCommands;
-    m_enumState         = &metaEnumState;
+    m_enumAttr = &metaEnumAttr;
+    m_enumFeatures = &metaEnumFeatures;
+    m_enumCommands = &metaEnumCommands;
+    m_enumState = &metaEnumState;
     m_specificInterface = qobject_cast<ClimateInterface *>(this);
     initializeSupportedFeatures(config);
 
-    Config *   configObj = Config::getInstance();
-    UnitSystem us        = configObj->getUnitSystem();
-    if (us == Config::METRIC) {
+    Config *         configObj = Config::getInstance();
+    UnitSystem::Enum us = configObj->getUnitSystem();
+    if (us == UnitSystem::METRIC) {
         m_temperatureUnit = "ºC";
     } else {
         m_temperatureUnit = "ºF";
@@ -132,7 +132,7 @@ Climate::Climate(const QVariantMap &config, IntegrationInterface *integrationObj
     emit temperatureUnitChanged();
 
     QObject::connect(configObj, &Config::unitSystemChanged, this, [=]() {
-        if (configObj->getUnitSystem() == Config::METRIC) {
+        if (configObj->getUnitSystem() == UnitSystem::METRIC) {
             m_temperatureUnit = "ºC";
         } else {
             m_temperatureUnit = "ºF";

--- a/sources/hardware/linux/hw_factory_linux.cpp
+++ b/sources/hardware/linux/hw_factory_linux.cpp
@@ -74,7 +74,7 @@ SystemService *HardwareFactoryLinux::buildSystemService(const QVariantMap &confi
     QVariantMap systemdCfg = ConfigUtil::getValue(config, HW_CFG_SYSTEMD).toMap();
     QVariantMap serviceCfg = systemdCfg.value(HW_CFG_SYSTEMD_SERVICES).toMap();
 
-    QMap<SystemServiceName, QString> serviceNameMap;
+    QMap<SystemServiceName::Enum, QString> serviceNameMap;
     serviceNameMap.insert(SystemServiceName::WIFI,
                           serviceCfg.value(HW_CFG_SERVICE_WIFI, HW_DEF_SERVICE_WIFI).toString());
     serviceNameMap.insert(SystemServiceName::NAME_RESOLUTION,

--- a/sources/hardware/linux/systemd.cpp
+++ b/sources/hardware/linux/systemd.cpp
@@ -30,7 +30,7 @@
 static Q_LOGGING_CATEGORY(CLASS_LC, "systemd");
 
 // TODO(mze) direct d-bus interaction? https://doc.qt.io/qt-5/qtdbus-index.html
-Systemd::Systemd(const QMap<SystemServiceName, QString> &serviceNameMap, QObject *parent)
+Systemd::Systemd(const QMap<SystemServiceName::Enum, QString> &serviceNameMap, QObject *parent)
     : SystemService(parent),
       m_useSudo(HW_DEF_SYSTEMD_SUDO),
       m_systemctlTimeout(HW_DEF_SYSTEMD_TIMEOUT),
@@ -41,22 +41,22 @@ void Systemd::setUseSudo(bool sudo) { m_useSudo = sudo; }
 
 bool Systemd::isUseSudo() { return m_useSudo; }
 
-bool Systemd::startService(SystemServiceName serviceName) {
+bool Systemd::startService(SystemServiceName::Enum serviceName) {
     QString cmd = "systemctl start %1";
     return launch(cmd.arg(m_serviceNameMap.value(serviceName)));
 }
 
-bool Systemd::stopService(SystemServiceName serviceName) {
+bool Systemd::stopService(SystemServiceName::Enum serviceName) {
     QString cmd = "systemctl stop %1";
     return launch(cmd.arg(m_serviceNameMap.value(serviceName)));
 }
 
-bool Systemd::restartService(SystemServiceName serviceName) {
+bool Systemd::restartService(SystemServiceName::Enum serviceName) {
     QString cmd = "systemctl restart %1";
     return launch(cmd.arg(m_serviceNameMap.value(serviceName)));
 }
 
-bool Systemd::reloadService(SystemServiceName serviceName) {
+bool Systemd::reloadService(SystemServiceName::Enum serviceName) {
     QString cmd = "systemctl reload %1";
     return launch(cmd.arg(m_serviceNameMap.value(serviceName)));
 }

--- a/sources/hardware/linux/systemd.h
+++ b/sources/hardware/linux/systemd.h
@@ -34,17 +34,17 @@ class Systemd : public SystemService {
     Q_OBJECT
 
  public:
-    explicit Systemd(const QMap<SystemServiceName, QString> &serviceNameMap, QObject *parent = nullptr);
+    explicit Systemd(const QMap<SystemServiceName::Enum, QString> &serviceNameMap, QObject *parent = nullptr);
 
     void setUseSudo(bool sudo);
     bool isUseSudo();
 
     // SystemService interface
  public:
-    Q_INVOKABLE bool startService(SystemServiceName serviceName) override;
-    Q_INVOKABLE bool stopService(SystemServiceName serviceName) override;
-    Q_INVOKABLE bool restartService(SystemServiceName serviceName) override;
-    Q_INVOKABLE bool reloadService(SystemServiceName serviceName) override;
+    Q_INVOKABLE bool startService(SystemServiceName::Enum serviceName) override;
+    Q_INVOKABLE bool stopService(SystemServiceName::Enum serviceName) override;
+    Q_INVOKABLE bool restartService(SystemServiceName::Enum serviceName) override;
+    Q_INVOKABLE bool reloadService(SystemServiceName::Enum serviceName) override;
 
     int  systemctlTimeout() const;
     void setSystemctlTimeout(int systemctlTimeout);
@@ -52,7 +52,8 @@ class Systemd : public SystemService {
  private:
     bool launch(const QString &command);
 
-    bool                             m_useSudo;
-    int                              m_systemctlTimeout;
-    QMap<SystemServiceName, QString> m_serviceNameMap;
+    bool m_useSudo;
+    int  m_systemctlTimeout;
+
+    QMap<SystemServiceName::Enum, QString> m_serviceNameMap;
 };

--- a/sources/hardware/linux/wifi_shellscripts.cpp
+++ b/sources/hardware/linux/wifi_shellscripts.cpp
@@ -78,7 +78,7 @@ bool WifiShellScripts::clearConfiguredNetworks() {
     return true;
 }
 
-bool WifiShellScripts::join(const QString &ssid, const QString &password, WifiSecurity security) {
+bool WifiShellScripts::join(const QString &ssid, const QString &password, WifiSecurity::Enum security) {
     if (!validateAuthentication(security, password)) {
         return false;
     }

--- a/sources/hardware/linux/wifi_shellscripts.h
+++ b/sources/hardware/linux/wifi_shellscripts.h
@@ -43,10 +43,10 @@ class WifiShellScripts : public WifiControl {
     Q_INVOKABLE bool reset() override;
     Q_INVOKABLE bool clearConfiguredNetworks() override;
     Q_INVOKABLE bool join(const QString &ssid, const QString &password,
-                                  WifiSecurity security = WifiSecurity::DEFAULT) override;
+                          WifiSecurity::Enum security = WifiSecurity::DEFAULT) override;
     Q_INVOKABLE bool isConnected() override;
     Q_INVOKABLE void startNetworkScan() override;
-    Q_INVOKABLE  bool startAccessPoint() override;
+    Q_INVOKABLE bool startAccessPoint() override;
 
     QString countryCode() override;
     void    setCountryCode(const QString &countryCode) override;

--- a/sources/hardware/linux/wifi_wpasupplicant.cpp
+++ b/sources/hardware/linux/wifi_wpasupplicant.cpp
@@ -175,7 +175,7 @@ bool WifiWpaSupplicant::clearConfiguredNetworks() {
     return true;
 }
 
-bool WifiWpaSupplicant::join(const QString& ssid, const QString& password, WifiSecurity security) {
+bool WifiWpaSupplicant::join(const QString& ssid, const QString& password, WifiSecurity::Enum security) {
     qCDebug(CLASS_LC) << "Joining network:" << ssid << security;
 
     // For more details about network creation & security option see:
@@ -675,7 +675,7 @@ bool WifiWpaSupplicant::addBSS(int networkId) {
         }
     }
 
-    WifiSecurity security = getSecurityFromFlags(flags, networkId);
+    WifiSecurity::Enum security = getSecurityFromFlags(flags, networkId);
     WifiNetwork  network{id, ssid, bssid, level, security, flags.contains("[WPS")};
 
     // qCDebug(CLASS_LC) << "Network found:" << network; // too verbose
@@ -685,10 +685,10 @@ bool WifiWpaSupplicant::addBSS(int networkId) {
     return true;
 }
 
-WifiSecurity WifiWpaSupplicant::getSecurityFromFlags(const QString& flags, int networkId) {
+WifiSecurity::Enum WifiWpaSupplicant::getSecurityFromFlags(const QString& flags, int networkId) {
     // Partial implementation of security flags, e.g. no support for EAP
     // Sufficiant for now...
-    WifiSecurity auth;
+    WifiSecurity::Enum auth;
     if (flags.indexOf("[WPA2-EAP") >= 0) {
         auth = WifiSecurity::WPA2_EAP;
     } else if (flags.indexOf("[WPA-EAP") >= 0) {

--- a/sources/hardware/linux/wifi_wpasupplicant.h
+++ b/sources/hardware/linux/wifi_wpasupplicant.h
@@ -82,7 +82,7 @@ class WifiWpaSupplicant : public WifiControl {
     Q_INVOKABLE bool reset() override;
     Q_INVOKABLE bool clearConfiguredNetworks() override;
     Q_INVOKABLE bool join(const QString& ssid, const QString& password,
-                          WifiSecurity security = WifiSecurity::DEFAULT) override;
+                          WifiSecurity::Enum security = WifiSecurity::DEFAULT) override;
     Q_INVOKABLE void startNetworkScan() override;
     Q_INVOKABLE bool startAccessPoint() override;
 
@@ -202,7 +202,7 @@ class WifiWpaSupplicant : public WifiControl {
      * @param networkId optional network identification to retrieve more information if required
      * @return Security enumeration
      */
-    WifiSecurity getSecurityFromFlags(const QString& flags, int networkId = -1);
+    WifiSecurity::Enum getSecurityFromFlags(const QString& flags, int networkId = -1);
 
     /**
      * @brief getConfiguredNetworks Returns the configured networks with command LIST_NETWORKS

--- a/sources/hardware/mock/systemservice_mock.cpp
+++ b/sources/hardware/mock/systemservice_mock.cpp
@@ -29,12 +29,12 @@ static Q_LOGGING_CATEGORY(CLASS_LC, "SysSrvMock");
 
 SystemServiceMock::SystemServiceMock(QObject *parent) : SystemService(parent) { qCDebug(CLASS_LC) << Q_FUNC_INFO; }
 
-bool SystemServiceMock::startService(SystemServiceName serviceName) {
+bool SystemServiceMock::startService(SystemServiceName::Enum serviceName) {
     qCDebug(CLASS_LC) << "start service:" << serviceName;
     return true;
 }
 
-bool SystemServiceMock::stopService(SystemServiceName serviceName) {
+bool SystemServiceMock::stopService(SystemServiceName::Enum serviceName) {
     qCDebug(CLASS_LC) << "stop service:" << serviceName;
     return true;
 }

--- a/sources/hardware/mock/systemservice_mock.h
+++ b/sources/hardware/mock/systemservice_mock.h
@@ -34,6 +34,6 @@ class SystemServiceMock : public SystemService {
 
     // SystemService interface
  public:
-    Q_INVOKABLE bool startService(SystemServiceName serviceName) override;
-    Q_INVOKABLE bool stopService(SystemServiceName serviceName) override;
+    Q_INVOKABLE bool startService(SystemServiceName::Enum serviceName) override;
+    Q_INVOKABLE bool stopService(SystemServiceName::Enum serviceName) override;
 };

--- a/sources/hardware/mock/wifi_mock.cpp
+++ b/sources/hardware/mock/wifi_mock.cpp
@@ -54,7 +54,7 @@ bool WifiMock::clearConfiguredNetworks() {
     return true;
 }
 
-bool WifiMock::join(const QString &ssid, const QString &password, WifiSecurity security) {
+bool WifiMock::join(const QString &ssid, const QString &password, WifiSecurity::Enum security) {
     qCDebug(CLASS_LC) << "join " << ssid;
 
     if (!validateAuthentication(security, password)) {
@@ -79,6 +79,7 @@ void WifiMock::startNetworkScan() {
     m_scanResults.clear();
     m_scanResults.append({"0", "Mock Net", "34:31:c4:e1:d3:97", -77, WifiSecurity::WPA_PSK});
     m_scanResults.append({"1", "Guest Network", "33:31:44:55:66:77", -66, WifiSecurity::NONE_OPEN});
+    m_scanResults.append({"2", "FooBar", "33:31:44:55:66:88", -70, WifiSecurity::WPA2_PSK});
 
     setScanStatus(ScanOk);
 

--- a/sources/hardware/mock/wifi_mock.h
+++ b/sources/hardware/mock/wifi_mock.h
@@ -41,7 +41,7 @@ class WifiMock : public WifiControl {
     Q_INVOKABLE bool reset() override;
     Q_INVOKABLE bool clearConfiguredNetworks() override;
     Q_INVOKABLE bool join(const QString &ssid, const QString &password,
-                                  WifiSecurity security = WifiSecurity::DEFAULT) override;
+                          WifiSecurity::Enum security = WifiSecurity::DEFAULT) override;
     Q_INVOKABLE bool isConnected() override;
     Q_INVOKABLE void startNetworkScan() override;
     Q_INVOKABLE bool startAccessPoint() override;

--- a/sources/hardware/systemservice.cpp
+++ b/sources/hardware/systemservice.cpp
@@ -27,7 +27,7 @@ SystemService::SystemService(QObject *parent) : QObject(parent) {}
 /**
  * @brief SystemService::restartService default implementation: stops and starts service
  */
-bool SystemService::restartService(SystemServiceName serviceName) {
+bool SystemService::restartService(SystemServiceName::Enum serviceName) {
     stopService(serviceName);
     return startService(serviceName);
 }
@@ -35,7 +35,7 @@ bool SystemService::restartService(SystemServiceName serviceName) {
 /**
  * @brief SystemService::reloadService default implementation: stops and starts service
  */
-bool SystemService::reloadService(SystemServiceName serviceName) {
+bool SystemService::reloadService(SystemServiceName::Enum serviceName) {
     stopService(serviceName);
     return startService(serviceName);
 }

--- a/sources/hardware/systemservice.h
+++ b/sources/hardware/systemservice.h
@@ -41,26 +41,26 @@ class SystemService : public QObject {
      * @param serviceName the name of the service
      * @return true if the service was started successfully
      */
-    Q_INVOKABLE virtual bool startService(SystemServiceName serviceName) = 0;
+    Q_INVOKABLE virtual bool startService(SystemServiceName::Enum serviceName) = 0;
 
     /**
      * @brief Stopps the given service
      * @param serviceName the name of the service
      * @return true if the service was stopped successfully
      */
-    Q_INVOKABLE virtual bool stopService(SystemServiceName serviceName) = 0;
+    Q_INVOKABLE virtual bool stopService(SystemServiceName::Enum serviceName) = 0;
 
     /**
      * @brief Restarts the given service
      * @param serviceName the name of the service
      * @return true if the service was restarted successfully
      */
-    Q_INVOKABLE virtual bool restartService(SystemServiceName serviceName);
+    Q_INVOKABLE virtual bool restartService(SystemServiceName::Enum serviceName);
 
     /**
      * @brief Reloads the configuration of the given service
      * @param serviceName the name of the service
      * @return true if the service was reloaded successfully
      */
-    Q_INVOKABLE virtual bool reloadService(SystemServiceName serviceName);
+    Q_INVOKABLE virtual bool reloadService(SystemServiceName::Enum serviceName);
 };

--- a/sources/hardware/systemservice_name.h
+++ b/sources/hardware/systemservice_name.h
@@ -26,13 +26,17 @@
 
 /**
  * @brief Enum class for system services
- * @details Dedicated class for improved QML usability based on https://qml.guide/enums-in-qt-qml/
+ * @details Dedicated class for clearly separated enums and improved QML usability based on
+ * https://www.embeddeduse.com/2017/09/15/passing-enum-properties-between-c-and-qml/
+ *
+ * Note: the "typedef style" described in https://qml.guide/enums-in-qt-qml/ unfortunately doesn't work with
+ * "=== Strict Equality Comparison" in QML!
  */
-class SystemServiceNameEnum {
+class SystemServiceName {
     Q_GADGET
 
  public:
-    enum Value {
+    enum Enum {
         WIFI,
         WEBSERVER,
         DHCP,
@@ -41,10 +45,8 @@ class SystemServiceNameEnum {
         NTP,
         ZEROCONF
     };
-    Q_ENUM(Value)
+    Q_ENUM(Enum)
 
  private:
-    SystemServiceNameEnum() {}
+    SystemServiceName() {}
 };
-
-typedef SystemServiceNameEnum::Value SystemServiceName;

--- a/sources/hardware/wifi_control.cpp
+++ b/sources/hardware/wifi_control.cpp
@@ -46,7 +46,7 @@ WifiControl::~WifiControl() {
     stopScanTimer();
 }
 
-bool WifiControl::validateAuthentication(WifiSecurity security, const QString& preSharedKey) {
+bool WifiControl::validateAuthentication(WifiSecurity::Enum security, const QString& preSharedKey) {
     switch (security) {
         case WifiSecurity::IEEE8021X:
         case WifiSecurity::WPA_EAP:

--- a/sources/hardware/wifi_control.h
+++ b/sources/hardware/wifi_control.h
@@ -106,7 +106,7 @@ class WifiControl : public QObject {
      *         false if connection setup failed.
      */
     Q_INVOKABLE virtual bool join(const QString &ssid, const QString &password,
-                                  WifiSecurity security = WifiSecurity::DEFAULT) = 0;
+                                  WifiSecurity::Enum security = WifiSecurity::DEFAULT) = 0;
 
     /**
      * @brief Checks if the WiFi connection is established
@@ -237,7 +237,7 @@ class WifiControl : public QObject {
     /**
      * @brief validateAuthentication Validates the authentication mode and pre shared key
      */
-    bool validateAuthentication(WifiSecurity security, const QString &preSharedKey);
+    bool validateAuthentication(WifiSecurity::Enum security, const QString &preSharedKey);
 
     /**
      * @brief Set Wifi connection status.

--- a/sources/hardware/wifi_network.h
+++ b/sources/hardware/wifi_network.h
@@ -39,15 +39,15 @@ class WifiNetwork {
     Q_PROPERTY(QString name READ name CONSTANT)
     Q_PROPERTY(QString bssid READ bssid CONSTANT)
     Q_PROPERTY(int rssi READ rssi CONSTANT)
-    Q_PROPERTY(SignalStrength signalStrength READ signalStrength CONSTANT)
+    Q_PROPERTY(SignalStrength::Enum signalStrength READ signalStrength CONSTANT)
     Q_PROPERTY(bool encrypted READ isEncrypted CONSTANT)
-    Q_PROPERTY(WifiSecurity security READ security CONSTANT)
+    Q_PROPERTY(WifiSecurity::Enum security READ security CONSTANT)
     Q_PROPERTY(bool wpsAvailable READ isWpsAvailable CONSTANT)
     Q_PROPERTY(bool connected READ isConnected CONSTANT)
 
  public:
     WifiNetwork() {}
-    WifiNetwork(QString id, QString name, QString bssid, int rssi, WifiSecurity security = WifiSecurity::WPA_PSK,
+    WifiNetwork(QString id, QString name, QString bssid, int rssi, WifiSecurity::Enum security = WifiSecurity::WPA_PSK,
                 bool wpsAvailable = false, bool connected = false)
         : m_id(id),
           m_name(name),
@@ -82,20 +82,20 @@ class WifiNetwork {
      */
     bool isEncrypted() const { return m_security != WifiSecurity::NONE_OPEN; }  // what about NoneWep?
 
-    WifiSecurity security() const { return m_security; }
+    WifiSecurity::Enum security() const { return m_security; }
 
     bool isWpsAvailable() const { return m_wpsAvailable; }
 
     bool isConnected() const { return m_connected; }
 
-    SignalStrength signalStrength() const { return SignalStrengthEnum::fromRssi(m_rssi); }
+    SignalStrength::Enum signalStrength() const { return SignalStrength::fromRssi(m_rssi); }
 
  private:
-    QString      m_id;
-    QString      m_name;
-    QString      m_bssid;
-    int          m_rssi = -100;
-    WifiSecurity m_security = WifiSecurity::WPA_PSK;
-    bool         m_wpsAvailable = false;
-    bool         m_connected = false;
+    QString            m_id;
+    QString            m_name;
+    QString            m_bssid;
+    int                m_rssi = -100;
+    WifiSecurity::Enum m_security = WifiSecurity::WPA_PSK;
+    bool               m_wpsAvailable = false;
+    bool               m_connected = false;
 };

--- a/sources/hardware/wifi_security.h
+++ b/sources/hardware/wifi_security.h
@@ -26,13 +26,17 @@
 
 /**
  * @brief Enum class for WiFi security.
- * @details Dedicated class for improved QML usability based on https://qml.guide/enums-in-qt-qml/
+ * @details Dedicated class for clearly separated enums and improved QML usability based on
+ * https://www.embeddeduse.com/2017/09/15/passing-enum-properties-between-c-and-qml/
+ *
+ * Note: the "typedef style" described in https://qml.guide/enums-in-qt-qml/ unfortunately doesn't work with
+ * "=== Strict Equality Comparison" in QML!
  */
-class WifiSecurityEnum {
+class WifiSecurity {
     Q_GADGET
 
  public:
-    enum Value {
+    enum Enum {
         DEFAULT,
         NONE_OPEN,
         NONE_WEP,
@@ -43,10 +47,8 @@ class WifiSecurityEnum {
         WPA2_PSK,
         WPA2_EAP
     };
-    Q_ENUM(Value)
+    Q_ENUM(Enum)
 
  private:
-    WifiSecurityEnum() {}
+    WifiSecurity() {}
 };
-
-typedef WifiSecurityEnum::Value WifiSecurity;

--- a/sources/hardware/wifi_signal.h
+++ b/sources/hardware/wifi_signal.h
@@ -26,22 +26,26 @@
 
 /**
  * @brief Enum class for WiFi signal strength.
- * @details Dedicated class for improved QML usability based on https://qml.guide/enums-in-qt-qml/
+ * @details Dedicated class for clearly separated enums and improved QML usability based on
+ * https://www.embeddeduse.com/2017/09/15/passing-enum-properties-between-c-and-qml/
+ *
+ * Note: the "typedef style" described in https://qml.guide/enums-in-qt-qml/ unfortunately doesn't work with
+ * "=== Strict Equality Comparison" in QML!
  */
-class SignalStrengthEnum {
+class SignalStrength {
     Q_GADGET
 
  public:
-    enum Value {
+    enum Enum {
         NONE,
         WEAK,
         OK,
         GOOD,
         EXCELLENT
     };
-    Q_ENUM(Value)
+    Q_ENUM(Enum)
 
-    static Value fromRssi(int rssi) {
+    static Enum fromRssi(int rssi) {
         // Calibration is based on "various Internet sources", taken from wpa_cute project
         if (rssi >= -60)
             return EXCELLENT;
@@ -56,7 +60,5 @@ class SignalStrengthEnum {
     }
 
  private:
-    SignalStrengthEnum() {}
+    SignalStrength() {}
 };
-
-typedef SignalStrengthEnum::Value SignalStrength;

--- a/sources/hardware/wifi_status.h
+++ b/sources/hardware/wifi_status.h
@@ -39,7 +39,7 @@ class WifiStatus {
     Q_PROPERTY(QString ipAddress READ ipAddress CONSTANT)
     Q_PROPERTY(QString macAddress READ macAddress CONSTANT)
     Q_PROPERTY(int rssi READ rssi CONSTANT)
-    Q_PROPERTY(SignalStrength signalStrength READ signalStrength CONSTANT)
+    Q_PROPERTY(SignalStrength::Enum signalStrength READ signalStrength CONSTANT)
     Q_PROPERTY(bool connected READ isConnected CONSTANT)
 
  public:
@@ -81,7 +81,7 @@ class WifiStatus {
     /**
      * @brief signalStrength Signal strength classification based on rssi.
      */
-    SignalStrength signalStrength() const { return SignalStrengthEnum::fromRssi(m_rssi); }
+    SignalStrength::Enum signalStrength() const { return SignalStrength::fromRssi(m_rssi); }
 
     /**
      * @brief isConnected Returns the access point connection status.

--- a/sources/jsonfile.cpp
+++ b/sources/jsonfile.cpp
@@ -100,6 +100,10 @@ bool JsonFile::write(const QVariantMap &data) {
     }
     bool success = m_file.write(json) == json.size();
     m_file.close();
+    if (!success) {
+        m_error = m_file.errorString();
+        qCWarning(CLASS_LC) << "Error writing json file:" << m_error;
+    }
     return success;
 }
 

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -104,8 +104,7 @@ int main(int argc, char* argv[]) {
 
     qmlRegisterUncreatableType<Config>("Config", 1, 0, "Config",
                                        "Not creatable as it is a global object managed from cpp");
-    qmlRegisterUncreatableType<UnitSystem>("Config", 1, 0, "UnitSystem",
-                                       "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<UnitSystem>("Config", 1, 0, "UnitSystem", "Not creatable as it is an enum type");
 
     engine.rootContext()->setContextProperty("config", config);
     engine.rootContext()->setContextProperty("configError", configError);
@@ -140,16 +139,12 @@ int main(int argc, char* argv[]) {
 
     qmlRegisterUncreatableType<WifiNetwork>("WifiControl", 1, 0, "WifiNetwork",
                                             "Not creatable as it is an information object only");
-    // register all Qt enums (based on https://qml.guide/enums-in-qt-qml/)
-    qRegisterMetaType<SystemServiceName>("SystemServiceName");
-    qmlRegisterUncreatableType<SystemServiceNameEnum>("SystemService", 1, 0, "SystemServiceName",
-                                                      "Not creatable as it is an enum type");
-    qRegisterMetaType<WifiSecurity>("WifiSecurity");
-    qmlRegisterUncreatableType<WifiSecurityEnum>("WifiControl", 1, 0, "WifiSecurity",
-                                                 "Not creatable as it is an enum type");
-    qRegisterMetaType<SignalStrength>("SignalStrength");
-    qmlRegisterUncreatableType<SignalStrengthEnum>("WifiControl", 1, 0, "SignalStrength",
-                                                   "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<SystemServiceName>("SystemService", 1, 0, "SystemServiceName",
+                                                  "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<WifiSecurity>("WifiControl", 1, 0, "WifiSecurity",
+                                             "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<SignalStrength>("WifiControl", 1, 0, "SignalStrength",
+                                               "Not creatable as it is an enum type");
     qRegisterMetaType<WifiStatus>("WifiStatus");
     qmlRegisterUncreatableType<WifiStatus>("WifiControl", 1, 0, "WifiStatus",
                                            "Not creatable as it is an information object only");
@@ -221,7 +216,7 @@ int main(int argc, char* argv[]) {
     qmlRegisterSingletonType<StandbyControl>("StandbyControl", 1, 0, "StandbyControl", &StandbyControl::getQMLInstance);
 
     // SOFTWARE UPDATE
-    QVariantMap     appUpdCfg      = config->getSettings().value("softwareupdate").toMap();
+    QVariantMap     appUpdCfg = config->getSettings().value("softwareupdate").toMap();
     SoftwareUpdate* softwareUpdate = new SoftwareUpdate(appUpdCfg, hwFactory->getBatteryFuelGauge());
     qmlRegisterSingletonType<SoftwareUpdate>("SoftwareUpdate", 1, 0, "SoftwareUpdate", &SoftwareUpdate::getQMLInstance);
 

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -97,13 +97,15 @@ int main(int argc, char* argv[]) {
         return 1;
     }
     Config* config = new Config(&engine, cmdLineHandler.configFile(), cmdLineHandler.configSchemaFile(), appPath);
-    if (!config->isValid()) {
+    if (!config->readConfig()) {
         qCCritical(CLASS_LC).noquote() << "Invalid configuration!" << endl << config->getError();
         configError = true;
     }
 
-    qmlRegisterUncreatableType<Config>("Config", 1, 0, "Config", "Not creatable as it is an enum type");
-    qRegisterMetaType<UnitSystem>("UnitSystem");
+    qmlRegisterUncreatableType<Config>("Config", 1, 0, "Config",
+                                       "Not creatable as it is a global object managed from cpp");
+    qmlRegisterUncreatableType<UnitSystem>("Config", 1, 0, "UnitSystem",
+                                       "Not creatable as it is an enum type");
 
     engine.rootContext()->setContextProperty("config", config);
     engine.rootContext()->setContextProperty("configError", configError);
@@ -132,25 +134,25 @@ int main(int argc, char* argv[]) {
     qmlRegisterType<Launcher>("Launcher", 1, 0, "Launcher");
     qmlRegisterType<JsonFile>("JsonFile", 1, 0, "JsonFile");
 
-    //    qmlRegisterType<TouchEventFilter>("TouchEventFilter", 1, 0, "TouchEventFilter");
     TouchEventFilter* touchEventFilter = new TouchEventFilter();
     qmlRegisterSingletonType<TouchEventFilter>("TouchEventFilter", 1, 0, "TouchEventFilter",
                                                &TouchEventFilter::getInstance);
 
-    qmlRegisterUncreatableType<SystemServiceNameEnum>("SystemService", 1, 0, "SystemServiceNameEnum",
-                                                      "Not creatable as it is an enum type");
-    qRegisterMetaType<SystemServiceName>("SystemServiceName");
     qmlRegisterUncreatableType<WifiNetwork>("WifiControl", 1, 0, "WifiNetwork",
                                             "Not creatable as it is an information object only");
-    qmlRegisterUncreatableType<WifiSecurityEnum>("WifiControl", 1, 0, "WifiSecurityEnum",
-                                                 "Not creatable as it is an enum type");
+    // register all Qt enums (based on https://qml.guide/enums-in-qt-qml/)
+    qRegisterMetaType<SystemServiceName>("SystemServiceName");
+    qmlRegisterUncreatableType<SystemServiceNameEnum>("SystemService", 1, 0, "SystemServiceName",
+                                                      "Not creatable as it is an enum type");
     qRegisterMetaType<WifiSecurity>("WifiSecurity");
-    qmlRegisterUncreatableType<SignalStrengthEnum>("WifiControl", 1, 0, "SignalStrengthEnum",
-                                                   "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<WifiSecurityEnum>("WifiControl", 1, 0, "WifiSecurity",
+                                                 "Not creatable as it is an enum type");
     qRegisterMetaType<SignalStrength>("SignalStrength");
+    qmlRegisterUncreatableType<SignalStrengthEnum>("WifiControl", 1, 0, "SignalStrength",
+                                                   "Not creatable as it is an enum type");
+    qRegisterMetaType<WifiStatus>("WifiStatus");
     qmlRegisterUncreatableType<WifiStatus>("WifiControl", 1, 0, "WifiStatus",
                                            "Not creatable as it is an information object only");
-    qRegisterMetaType<WifiStatus>("WifiStatus");
 
     // DRIVERS
     HardwareFactory* hwFactory = HardwareFactory::build(


### PR DESCRIPTION
Fixes the enum handling in QML. The `UnitSystem` enum can now be used in QML and strict equality comparison `===` is now also working.

- UnitSystem is persisted as enum in config.json.
- The Config class has been cleaned up and a few issues corrected.
- CPU temperature is displayed in Celsius or Fahrenheit.

PR YIO-Remote/integrations.library#9 must be merged first and a new integrations.library release be created. The new release version must be set in dependencies.cfg before this PR is merged!

This closes #442 and #473 