### PR TITLE
feat: reset remote to defaults with button press on boot

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -33,6 +33,7 @@ import Battery 1.0
 import DisplayControl 1.0
 import Proximity 1.0
 import StandbyControl 1.0
+import ButtonHandler 1.0
 
 import "qrc:/basic_ui" as BasicUI // TODO: can this be done in a singleton?
 
@@ -82,6 +83,7 @@ ApplicationWindow {
     // CONFIGURATION
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     Component.onCompleted: {
+        console.debug("Reset button combination was pressed: " + ButtonHandler.resetButtonsPressed());
         console.debug("UI loading");
         console.debug("Resolution: " + Style.screen.width + "x" + Style.screen.height);
         console.debug("Pixel density: " + Style.screen.pixelDensity);

--- a/main.qml
+++ b/main.qml
@@ -33,7 +33,6 @@ import Battery 1.0
 import DisplayControl 1.0
 import Proximity 1.0
 import StandbyControl 1.0
-import ButtonHandler 1.0
 
 import "qrc:/basic_ui" as BasicUI // TODO: can this be done in a singleton?
 
@@ -83,7 +82,6 @@ ApplicationWindow {
     // CONFIGURATION
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     Component.onCompleted: {
-        console.debug("Reset button combination was pressed: " + ButtonHandler.resetButtonsPressed());
         console.debug("UI loading");
         console.debug("Resolution: " + Style.screen.width + "x" + Style.screen.height);
         console.debug("Pixel density: " + Style.screen.pixelDensity);

--- a/remote.pro
+++ b/remote.pro
@@ -26,6 +26,9 @@ CONFIG += c++17 disable-desktop
 #disable qtquickcompiler for QML debugging!
 CONFIG += qtquickcompiler
 
+# needed for std::filesystem
+LIBS += -lstdc++fs
+
 DEFINES += QT_DEPRECATED_WARNINGS
 
 # SOFTWARE VERSION

--- a/remote.pro
+++ b/remote.pro
@@ -26,9 +26,6 @@ CONFIG += c++17 disable-desktop
 #disable qtquickcompiler for QML debugging!
 CONFIG += qtquickcompiler
 
-# needed for std::filesystem
-LIBS += -lstdc++fs
-
 DEFINES += QT_DEPRECATED_WARNINGS
 
 # SOFTWARE VERSION
@@ -258,8 +255,10 @@ linux {
             sources/hardware/linux/arm/displaycontrol_yio.cpp \
             sources/hardware/linux/arm/drv2605.cpp \
             sources/hardware/linux/arm/mcp23017_interrupt.cpp
-    }
 
+        # needed for std::filesystem
+        LIBS += -lstdc++fs
+    }
 }
 
 # Android specific files (empty template for now)

--- a/remote.pro
+++ b/remote.pro
@@ -22,7 +22,7 @@
  #############################################################################/
 
 QT += qml quick websockets quickcontrols2 bluetooth
-CONFIG += c++14 disable-desktop
+CONFIG += c++17 disable-desktop
 #disable qtquickcompiler for QML debugging!
 CONFIG += qtquickcompiler
 

--- a/sources/hardware/buttonhandler.cpp
+++ b/sources/hardware/buttonhandler.cpp
@@ -35,7 +35,7 @@ ButtonHandler::ButtonHandler(InterruptHandler *interruptHandler, YioAPI *api, QO
 
     // connect to interrupt handler
     connect(m_itnerruptHandler, &InterruptHandler::interruptEvent, this, &ButtonHandler::onInterrupt);
-    connect(m_itnerruptHandler, &InterruptHandler::resetEvent, this, &ButtonHandler::onResetEvent);
+    m_resetButtonsPressed = m_itnerruptHandler->m_wasResetPress;
 
     // connect to API
     connect(m_api, &YioAPI::buttonPressed, this, &ButtonHandler::onYIOAPIPressed);
@@ -137,8 +137,6 @@ void ButtonHandler::onInterrupt(int event) {
         } break;
     }
 }
-
-void ButtonHandler::onResetEvent() { m_resetButtonsPressed = true; }
 
 void ButtonHandler::onYIOAPIPressed(QString button) {
     if (button == "dpad up") {

--- a/sources/hardware/buttonhandler.cpp
+++ b/sources/hardware/buttonhandler.cpp
@@ -30,11 +30,12 @@ static Q_LOGGING_CATEGORY(CLASS_LC, "hw.buttonhandler");
 ButtonHandler *ButtonHandler::s_instance = nullptr;
 
 ButtonHandler::ButtonHandler(InterruptHandler *interruptHandler, YioAPI *api, QObject *parent)
-    : QObject(parent), m_itnerruptHandler(interruptHandler), m_api(api) {
+    : QObject(parent), m_itnerruptHandler(interruptHandler), m_api(api), m_resetButtonsPressed(false) {
     s_instance = this;
 
     // connect to interrupt handler
     connect(m_itnerruptHandler, &InterruptHandler::interruptEvent, this, &ButtonHandler::onInterrupt);
+    connect(m_itnerruptHandler, &InterruptHandler::resetEvent, this, &ButtonHandler::onResetEvent);
 
     // connect to API
     connect(m_api, &YioAPI::buttonPressed, this, &ButtonHandler::onYIOAPIPressed);
@@ -136,6 +137,8 @@ void ButtonHandler::onInterrupt(int event) {
         } break;
     }
 }
+
+void ButtonHandler::onResetEvent() { m_resetButtonsPressed = true; }
 
 void ButtonHandler::onYIOAPIPressed(QString button) {
     if (button == "dpad up") {

--- a/sources/hardware/buttonhandler.h
+++ b/sources/hardware/buttonhandler.h
@@ -82,7 +82,6 @@ class ButtonHandler : public QObject {
 
  private slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
     void onInterrupt(int event);
-    void onResetEvent();
     void onYIOAPIPressed(QString button);
     void onYIOAPIReleased(QString button);
 };

--- a/sources/hardware/buttonhandler.h
+++ b/sources/hardware/buttonhandler.h
@@ -65,7 +65,7 @@ class ButtonHandler : public QObject {
     explicit ButtonHandler(InterruptHandler* interruptHandler, YioAPI* api, QObject* parent = nullptr);
     virtual ~ButtonHandler();
 
-    Q_INVOKABLE bool resetButtonsPressed() { return m_resetButtonsPressed; }
+    bool resetButtonsPressed() { return m_resetButtonsPressed; }
 
     static ButtonHandler* getInstance() { return s_instance; }
     static QObject*       getQMLInstance(QQmlEngine* engine, QJSEngine* scriptEngine);

--- a/sources/hardware/buttonhandler.h
+++ b/sources/hardware/buttonhandler.h
@@ -65,6 +65,8 @@ class ButtonHandler : public QObject {
     explicit ButtonHandler(InterruptHandler* interruptHandler, YioAPI* api, QObject* parent = nullptr);
     virtual ~ButtonHandler();
 
+    Q_INVOKABLE bool resetButtonsPressed() { return m_resetButtonsPressed; }
+
     static ButtonHandler* getInstance() { return s_instance; }
     static QObject*       getQMLInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
 
@@ -76,12 +78,11 @@ class ButtonHandler : public QObject {
     static ButtonHandler* s_instance;
     InterruptHandler*     m_itnerruptHandler;
     YioAPI*               m_api;
-
-    int m_buttonPressed  = -1;
-    int m_buttonReleased = -1;
+    bool                  m_resetButtonsPressed;
 
  private slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
     void onInterrupt(int event);
+    void onResetEvent();
     void onYIOAPIPressed(QString button);
     void onYIOAPIReleased(QString button);
 };

--- a/sources/hardware/interrupthandler.h
+++ b/sources/hardware/interrupthandler.h
@@ -65,9 +65,10 @@ class InterruptHandler : public Device {
 
     Q_INVOKABLE virtual void shutdown() = 0;
 
+    bool m_wasResetPress = false;
+
  signals:
     void interruptEvent(int event);
-    void resetEvent();
 
  protected:
     explicit InterruptHandler(QString name, QObject *parent = nullptr) : Device(name, parent) {}

--- a/sources/hardware/interrupthandler.h
+++ b/sources/hardware/interrupthandler.h
@@ -67,6 +67,7 @@ class InterruptHandler : public Device {
 
  signals:
     void interruptEvent(int event);
+    void resetEvent();
 
  protected:
     explicit InterruptHandler(QString name, QObject *parent = nullptr) : Device(name, parent) {}

--- a/sources/hardware/linux/arm/mcp23017_handler.h
+++ b/sources/hardware/linux/arm/mcp23017_handler.h
@@ -22,16 +22,16 @@
 
 #pragma once
 
-#include <QLoggingCategory>
-#include <QString>
-#include <QtDebug>
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <time.h>
 #include <unistd.h>
 #include <wiringPi.h>
 #include <wiringPiI2C.h>
+
+#include <QLoggingCategory>
+#include <QString>
+#include <QtDebug>
 
 #include "../../interrupthandler.h"
 
@@ -120,6 +120,16 @@ class MCP23017 {
         wiringPiI2CReadReg8(m_i2cFd, MCP23017_INTCAPB);
 
         return true;
+    }
+
+    bool readReset() {
+        // read initial state to determine if reset is needed
+        int gpioB = wiringPiI2CReadReg8(m_i2cFd, MCP23017_GPIOB);
+        if (!(gpioB & 0x040) && !(gpioB & 0x080) && !(gpioB & 0x04)) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     int readInterrupt() {

--- a/sources/hardware/linux/arm/mcp23017_interrupt.cpp
+++ b/sources/hardware/linux/arm/mcp23017_interrupt.cpp
@@ -102,6 +102,10 @@ bool Mcp23017InterruptHandler::setupGPIO() {
     notifier->addPath(m_gpioValueDevice);
     connect(notifier, &QFileSystemWatcher::fileChanged, this, &Mcp23017InterruptHandler::interruptHandler);
 
+    if (mcp.readReset()) {
+        emit resetEvent();
+    }
+
     return true;
 }
 

--- a/sources/hardware/linux/arm/mcp23017_interrupt.cpp
+++ b/sources/hardware/linux/arm/mcp23017_interrupt.cpp
@@ -103,7 +103,7 @@ bool Mcp23017InterruptHandler::setupGPIO() {
     connect(notifier, &QFileSystemWatcher::fileChanged, this, &Mcp23017InterruptHandler::interruptHandler);
 
     if (mcp.readReset()) {
-        emit resetEvent();
+        m_wasResetPress = true;
     }
 
     return true;

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -30,7 +30,9 @@
 #include <QQmlContext>
 #include <QQuickWindow>
 #include <QtDebug>
+#if defined(Q_PROCESSOR_ARM)
 #include <filesystem>
+#endif
 
 #include "bluetooth.h"
 #include "commandlinehandler.h"
@@ -208,7 +210,8 @@ int main(int argc, char* argv[]) {
     ButtonHandler* buttonHandler = new ButtonHandler(hwFactory->getInterruptHandler(), yioapi);
     qmlRegisterSingletonType<ButtonHandler>("ButtonHandler", 1, 0, "ButtonHandler", &ButtonHandler::getQMLInstance);
 
-    // reset combination was pressed on startup
+#if defined(Q_PROCESSOR_ARM)
+    // reset combination was pressed on startup (only on the remote hardware)
     if (buttonHandler->resetButtonsPressed()) {
         QString defaultConfigPath = qEnvironmentVariable(Environment::ENV_YIO_APP_DIR, appPath) + "/config.json";
 
@@ -246,6 +249,7 @@ int main(int argc, char* argv[]) {
             notifications.add(true, QGuiApplication::tr("Default config file not found. Cannot restore to defaults."));
         }
     }
+#endif
 
     // STANDBY CONTROL
     StandbyControl* standbyControl =

--- a/translations/en_US.ts
+++ b/translations/en_US.ts
@@ -15,7 +15,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/settings/About.qml" line="50"/>
+        <location filename="../basic_ui/settings/About.qml" line="51"/>
         <source>
 
 To learn more about the project, visit
@@ -122,9 +122,9 @@ To learn more about the project, visit
     </message>
 </context>
 <context>
-    <name>BluetoothThread</name>
+    <name>BluetoothControl</name>
     <message>
-        <location filename="../sources/bluetootharea.cpp" line="126"/>
+        <location filename="../sources/bluetooth.cpp" line="41"/>
         <source>Bluetooth device was not found.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -538,7 +538,7 @@ to set up YIO remote</source>
     <name>JsonFile</name>
     <message>
         <location filename="../sources/jsonfile.cpp" line="80"/>
-        <location filename="../sources/jsonfile.cpp" line="129"/>
+        <location filename="../sources/jsonfile.cpp" line="133"/>
         <source>empty name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -553,12 +553,12 @@ to set up YIO remote</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/jsonfile.cpp" line="136"/>
+        <location filename="../sources/jsonfile.cpp" line="140"/>
         <source>cannot open file &apos;%1&apos; for reading: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/jsonfile.cpp" line="145"/>
+        <location filename="../sources/jsonfile.cpp" line="149"/>
         <source>invalid JSON file &apos;%1&apos; at offset %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -654,6 +654,19 @@ to set up YIO remote</source>
     <message>
         <location filename="../basic_ui/Profiles.qml" line="194"/>
         <source>To edit your profiles, use the web configurator tool in settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <location filename="../sources/main.cpp" line="236"/>
+        <source>An error occured while restoring to defaults. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../sources/main.cpp" line="240"/>
+        <source>Default config file not found. Cannot restore to defaults.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -791,7 +804,7 @@ Navigate your internet browser to: http://</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../setup/SetupStep3.qml" line="164"/>
+        <location filename="../setup/SetupStep3.qml" line="166"/>
         <source>Join other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -906,7 +919,7 @@ a power source and wait until it starts blinking.
 <context>
     <name>SetupStep8</name>
     <message>
-        <location filename="../setup/SetupStep8.qml" line="139"/>
+        <location filename="../setup/SetupStep8.qml" line="136"/>
         <source>Setting up your YIO Dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1115,37 +1128,37 @@ YIO remote %1</source>
 <context>
     <name>System</name>
     <message>
-        <location filename="../basic_ui/settings/System.qml" line="79"/>
+        <location filename="../basic_ui/settings/System.qml" line="94"/>
         <source>Unit system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/settings/System.qml" line="113"/>
+        <location filename="../basic_ui/settings/System.qml" line="133"/>
         <source>Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/settings/System.qml" line="148"/>
+        <location filename="../basic_ui/settings/System.qml" line="169"/>
         <source>Imperial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/settings/System.qml" line="167"/>
+        <location filename="../basic_ui/settings/System.qml" line="188"/>
         <source>Uptime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/settings/System.qml" line="194"/>
+        <location filename="../basic_ui/settings/System.qml" line="215"/>
         <source>CPU temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/settings/System.qml" line="218"/>
+        <location filename="../basic_ui/settings/System.qml" line="239"/>
         <source>Reboot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/settings/System.qml" line="232"/>
+        <location filename="../basic_ui/settings/System.qml" line="253"/>
         <source>Shutdown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1168,7 +1181,7 @@ YIO remote %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/settings/Wifi.qml" line="190"/>
+        <location filename="../basic_ui/settings/Wifi.qml" line="192"/>
         <source>Other networks</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/en_US.ts
+++ b/translations/en_US.ts
@@ -660,12 +660,12 @@ to set up YIO remote</source>
 <context>
     <name>QGuiApplication</name>
     <message>
-        <location filename="../sources/main.cpp" line="236"/>
+        <location filename="../sources/main.cpp" line="242"/>
         <source>An error occured while restoring to defaults. Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/main.cpp" line="240"/>
+        <location filename="../sources/main.cpp" line="246"/>
         <source>Default config file not found. Cannot restore to defaults.</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Pressing and holding `volume up`, `top left button (circle)` and `dpad down` on boot will reset the configuration file to default and create a marker file for first time setup. The remote will reboot.

**How to reset the remote to factory defaults:**
- Press and hold: `volume up`, `top left` and `dpad down` buttons while turning on the remote.
- When the remote reboots, immediately release these buttons
- The remote will start up with the setup wizard