### PR TITLE
fix: Blind open logic

### DIFF
--- a/sources/entities/blind.h
+++ b/sources/entities/blind.h
@@ -50,7 +50,7 @@ class Blind : public Entity, BlindInterface {
     void turnOn() override { open(); }
     void turnOff() override { close(); }
     int  position() override { return m_position; }
-    bool isOn() override { return m_state == BlindDef::CLOSED; }
+    bool isOn() override { return m_state == BlindDef::OPEN; }
     bool supportsOn() override { return isSupported(BlindDef::F_POSITION); }
 
     Blind(const QVariantMap& config, IntegrationInterface* integrationObj, QObject* parent = nullptr);


### PR DESCRIPTION
Fixed isOn() logic to return correct state:
1. turnOn() calls open()
2. open() sends BlindDef::C_OPEN command
3. Entity should have BlindDef::OPEN state once blind is open
4. Therefore, isOn() must return true if state is BlindDef::OPEN