### PR TITLE
fix: Climate entity UI fixes

### DIFF
--- a/components/climate/ui/Button.qml
+++ b/components/climate/ui/Button.qml
@@ -41,10 +41,11 @@ Comp.ButtonBase {
         color: Style.color.text
         opacity: 0.5
         text: {
-            if (obj.isSupported(Climate.F_TEMPERATURE))
-                return qsTr("Temperature: ") + obj.temperature + obj.temperatureUnit + translateHandler.emptyString
-            else if (obj.isSupported(Climate.F_TARGET_TEMPERATURE))
-                return qsTr("Temperature: ") + obj.targetTemperature + obj.temperatureUnit + translateHandler.emptyString
+            if (obj.isSupported(Climate.F_TEMPERATURE)) {
+                return qsTr("Temperature: ") + obj.temperature.toFixed(1) + obj.temperatureUnit + translateHandler.emptyString
+            } else if (obj.isSupported(Climate.F_TARGET_TEMPERATURE)) {
+                return qsTr("Temperature: ") + obj.targetTemperature.toFixed(1) + obj.temperatureUnit + translateHandler.emptyString
+            }
         }
         elide: Text.ElideRight
         wrapMode: Text.WordWrap

--- a/components/climate/ui/Card.qml
+++ b/components/climate/ui/Card.qml
@@ -179,6 +179,9 @@ Rectangle {
                 return i;
             }
         }
+        // TODO(marton) is there a case where a number cannot be found?
+        // In this case we could return the old value `dialListView.currentIndex`
+        return 0;
     }
 
     Component.onCompleted: {
@@ -317,16 +320,13 @@ Rectangle {
         onValueChanged: {
             Haptic.playEffect(Haptic.Bump);
             targetTemperature = value;
-            var i = findNumber(targetTemperature);
-            if (i)
-                dialListView.currentIndex = i;
+            dialListView.currentIndex = findNumber(targetTemperature);
         }
 
         onPressedChanged: {
             if (pressed) {
                 card.state = "moving"
-            }
-            else {
+            } else {
                 obj.setTargetTemperature(targetTemperature);
                 card.state = "notmoving"
             }
@@ -404,7 +404,11 @@ Rectangle {
 
         mouseArea.onClicked: {
             Haptic.playEffect(Haptic.Click);
-            obj.toggle();
+            if (obj.isOn) {
+                obj.turnOff();
+            } else {
+                obj.turnOn();
+            }
         }
     }
 
@@ -448,8 +452,9 @@ Rectangle {
         visible: modeButton.visible
 
         onStatusChanged: {
-            if (contextMenuLoader.status == Loader.Ready)
+            if (contextMenuLoader.status == Loader.Ready) {
                 contextMenuLoader.item.state = "open"
+            }
         }
     }
 }

--- a/components/climate/ui/ContextMenu.qml
+++ b/components/climate/ui/ContextMenu.qml
@@ -117,7 +117,7 @@ Rectangle {
                 MouseArea {
                     anchors.fill: parent
                     onClicked: {
-                        haptic.playEffect(Haptic.Click);
+                        Haptic.playEffect(Haptic.Click);
                         main.state = "closed";
                         if (list[index]["original"] === "Off")
                             climateObj.turnOff();

--- a/sources/entities/climate.cpp
+++ b/sources/entities/climate.cpp
@@ -89,15 +89,15 @@ void Climate::turnOff() { command(ClimateDef::C_OFF, ""); }
 bool Climate::isOn() { return m_state == ClimateDef::ON || m_state == ClimateDef::HEAT || m_state == ClimateDef::COOL; }
 
 bool Climate::supportsOn() {
-    if (isSupported(ClimateDef::F_OFF)) {
-        return true;
-    } else {
-        return false;
-    }
+    return isSupported(ClimateDef::F_OFF);
 }
 
 Climate::Climate(const QVariantMap &config, IntegrationInterface *integrationObj, QObject *parent)
-    : Entity(Type, config, integrationObj, parent), m_temperature(0), m_targetTemperature(0) {
+    : Entity(Type, config, integrationObj, parent),
+      m_temperature(0),
+      m_targetTemperature(0),
+      m_temperatureMax(0),
+      m_temperatureMin(0) {
     static QMetaEnum metaEnumAttr;
     static QMetaEnum metaEnumFeatures;
     static QMetaEnum metaEnumCommands;


### PR DESCRIPTION
- Fixed on / off button in card view (entity doesn't support toggle)
- Climate context menu mode selection wasn't working
- Fixed invalid number value in temperature dial
- Limit temperature display in button to one digit
- Initialized min & max temperature values for devices not supporting it