### PR TITLE
Add `addToQueue` extension to mediaplayer entity

### DIFF
--- a/dependencies.cfg
+++ b/dependencies.cfg
@@ -3,4 +3,4 @@
 #   name: dependency name
 #   separator: colon + optional white space
 #   version: git branch or tag
-integrations.library: v0.5.0
+integrations.library: v0.5.1

--- a/sources/entities/mediaplayer.cpp
+++ b/sources/entities/mediaplayer.cpp
@@ -146,6 +146,12 @@ void MediaPlayer::playMedia(const QString &itemKey, const QString &type) {
     map.insert("id", itemKey);
     command(MediaPlayerDef::C_PLAY_ITEM, map);
 }
+void MediaPlayer::addToQueue(const QString &itemKey, const QString &type) {
+    QVariantMap map;
+    map.insert("type", type);
+    map.insert("id", itemKey);
+    command(MediaPlayerDef::C_QUEUE, map);
+}
 void MediaPlayer::search(const QString &searchText, const QString &itemKey) {
     QVariantMap map;
     map["id"]   = itemKey;

--- a/sources/entities/mediaplayer.h
+++ b/sources/entities/mediaplayer.h
@@ -85,6 +85,7 @@ class MediaPlayer : public Entity, MediaPlayerInterface {
     // extension for media browsing
     Q_INVOKABLE void browse(QString command);  // Command item_key, "TOP", "BACK", "PLAY"
     Q_INVOKABLE void playMedia(const QString& itemKey, const QString& type);
+    Q_INVOKABLE void addToQueue(const QString& itemKey, const QString& type);
     Q_INVOKABLE void search(const QString& searchText, const QString& itemKey);  // Search
     Q_INVOKABLE void search(const QString& searchText);
     Q_INVOKABLE void getAlbum(const QString& id);


### PR DESCRIPTION
This PR will add an `addToQueue` extension to the `MediaPlayer` entity.

There seems to be some work already done preparing for the feature of queuing songs. This PR is needed in order for my "add to queue" implementation for the Spotify integration to work. See that PR here: https://github.com/YIO-Remote/integration.spotify/pull/16

Is this the way it was intended to be used? It's my first contribution and would be glad for any feedback!