### PR TITLE
fix: add progress to mediaplayer schema

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -160,6 +160,7 @@
                     "MEDIA_ALBUM",
                     "MEDIA_DURATION",
                     "MEDIA_POSITION",
+                    "MEDIA_PROGRESS",
                     "MEDIA_IMAGE",
                     "PLAY",
                     "PAUSE",


### PR DESCRIPTION
The progress feature exists in the code, but did not exist in the schema file yet. This caused issues when I tried adding a Sonos device via HA to YIO and likely did so for other devices as well. I have verified that adding my Sonos entity via the web configurator works correctly with this added entry in the schema.