### PR TITLE
feat: Configurable battery capacity

### DIFF
--- a/hardware-schema.json
+++ b/hardware-schema.json
@@ -124,6 +124,11 @@
       "title": "Battery fuel gauge",
       "properties": {
         "enabled": { "$ref": "#/definitions/enabled" },
+        "capacity": {
+            "type": "integer",
+            "minimum": 1000,
+            "default": 2500
+        },
         "i2c":  { "$ref": "#/definitions/i2c" }
       }
     },

--- a/hardware.json
+++ b/hardware.json
@@ -35,6 +35,7 @@
     },
     "batteryFuelGauge": {
         "enabled": true,
+        "capacity": 2500,
         "i2c": {
             "device": "/dev/i2c-3",
             "id": 85

--- a/sources/hardware/batteryfuelgauge.h
+++ b/sources/hardware/batteryfuelgauge.h
@@ -71,7 +71,10 @@ class BatteryFuelGauge : public Device {
     void chargingDone();
 
  protected:
-    explicit BatteryFuelGauge(QString name, QObject *parent = nullptr) : Device(name, parent) {}
+    explicit BatteryFuelGauge(QString name, int capacity, QObject *parent = nullptr)
+        : Device(name, parent), m_capacity(capacity) {
+        Q_ASSERT(capacity);
+    }
 
-    int m_capacity = 2500;
+    int m_capacity;
 };

--- a/sources/hardware/hw_config.h
+++ b/sources/hardware/hw_config.h
@@ -37,6 +37,7 @@
 #define HW_CFG_BTN_INTR_HANDLER   "buttonInterruptHandler"
 #define HW_CFG_BATTERY_CHARGER    "batteryCharger"
 #define HW_CFG_BATTERY_FUEL_GAUGE "batteryFuelGauge"
+#define HW_CFG_BATTERY_CAPACITY   "capacity"
 #define HW_CFG_HAPTIC_MOTOR       "hapticMotor"
 #define HW_CFG_GESTURE            "gesture"
 #define HW_CFG_LIGHT              "light"

--- a/sources/hardware/linux/arm/bq27441.h
+++ b/sources/hardware/linux/arm/bq27441.h
@@ -81,7 +81,7 @@ class BQ27441 : public BatteryFuelGauge {
     Q_OBJECT
 
  public:
-    explicit BQ27441(InterruptHandler *interruptHandler, const QString &i2cDevice,
+    explicit BQ27441(InterruptHandler *interruptHandler, int capacity, const QString &i2cDevice,
                      int i2cDeviceId = BQ27441_I2C_ADDRESS, QObject *parent = nullptr);
     ~BQ27441() override;
 

--- a/sources/hardware/linux/arm/hw_factory_yio.cpp
+++ b/sources/hardware/linux/arm/hw_factory_yio.cpp
@@ -42,6 +42,7 @@
 #include "mcp23017_interrupt.h"
 
 const QString HardwareFactoryYio::DEF_I2C_DEVICE = "/dev/i2c-3";
+const int HardwareFactoryYio::DEF_BATTERY_CAPACITY = 2500;
 
 static Q_LOGGING_CATEGORY(CLASS_LC, "hw.factory.yio");
 
@@ -187,10 +188,11 @@ BatteryCharger *HardwareFactoryYio::buildBatteryCharger(const QVariantMap &confi
 }
 
 BatteryFuelGauge *HardwareFactoryYio::buildBatteryFuelGauge(const QVariantMap &config) {
+    auto capacity = ConfigUtil::getValue(config, HW_CFG_BATTERY_CAPACITY, DEF_BATTERY_CAPACITY).toInt();
     auto dev = ConfigUtil::getValue(config, HW_CFG_PATH_I2C_DEV, DEF_I2C_DEVICE).toString();
     auto id = ConfigUtil::getValue(config, HW_CFG_PATH_I2C_ID, BQ27441_I2C_ADDRESS).toInt();
 
-    BatteryFuelGauge *device = new BQ27441(getInterruptHandler(), dev, id, this);
+    BatteryFuelGauge *device = new BQ27441(getInterruptHandler(), capacity, dev, id, this);
     connect(device, &Device::error, this, &HardwareFactoryYio::onError);
 
     return device;

--- a/sources/hardware/linux/arm/hw_factory_yio.h
+++ b/sources/hardware/linux/arm/hw_factory_yio.h
@@ -60,4 +60,5 @@ class HardwareFactoryYio : public HardwareFactoryLinux {
 
     // default values for YIO
     static const QString DEF_I2C_DEVICE;
+    static const int     DEF_BATTERY_CAPACITY;
 };

--- a/sources/hardware/mock/batteryfuelgauge_mock.h
+++ b/sources/hardware/mock/batteryfuelgauge_mock.h
@@ -28,9 +28,7 @@ class BatteryFuelGaugeMock : public BatteryFuelGauge {
     Q_OBJECT
 
  public:
-    explicit BatteryFuelGaugeMock(QObject* parent = nullptr) : BatteryFuelGauge("BatteryFuelGaugeMock", parent) {
-        setCapacity(2500);
-    }
+    explicit BatteryFuelGaugeMock(QObject* parent = nullptr) : BatteryFuelGauge("BatteryFuelGaugeMock", 2500, parent) {}
 
     ~BatteryFuelGaugeMock() override {}
 


### PR DESCRIPTION
Battery capacity can be configured in optional hardware.json property: `batteryFuelGauge.capacity`

This closes #498