### PR TITLE
Clean up factory reset & prepare for read-only root

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -35,7 +35,7 @@ jobs:
         - {
             name: "Linux Latest x64", artifact: "Linux-x64", build: "release",
             qmake-args: "CONFIG+=release",
-            os: ubuntu-latest
+            os: ubuntu-20.04
           }
         - {
             name: "macOS Latest x64", artifact: "macOS-x64", build: "release",
@@ -79,7 +79,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt update
-        sudo apt install libavahi-client-dev libgl1-mesa-dev
+        sudo apt install libavahi-client-dev libgl1-mesa-dev g++-8 libstdc++-8-dev
 
     - name: Download Qt Creator
       id: qt_creator

--- a/basic_ui/settings/System.qml
+++ b/basic_ui/settings/System.qml
@@ -311,5 +311,22 @@ Rectangle {
                 }
             }
         }
+
+        // TODO(marton/zehnm) only show factory reset button if: factoryReset.supported
+        // TODO(marton/zehnm) add user confirmation to make sure that the remote will be resetted
+        /*
+        Item {
+            width: parent.width; height: childrenRect.height + 30
+            BasicUI.CustomButton {
+                id: buttonFactoryReset
+                buttonText: qsTr("Factory reset") + translateHandler.emptyString
+                anchors { top: parent.top; topMargin: 30; left: parent.left; leftMargin: 40 }
+
+                mouseArea.onClicked: {
+                    factoryReset.performReset();
+                }
+            }
+        }
+        */
     }
 }

--- a/main.qml
+++ b/main.qml
@@ -95,7 +95,7 @@ ApplicationWindow {
         api.start();
 
         // load the integrations if it's not the first time setup
-        if (fileio.exists("/firstrun")) {
+        if (config.isFirstRun()) {
             console.debug("Starting first time setup");
             loader_main.setSource("qrc:/setup/Setup.qml");
             translateHandler.selectLanguage(config.settings.language);

--- a/remote.pro
+++ b/remote.pro
@@ -101,6 +101,7 @@ HEADERS += \
     sources/entities/switch.h \
     sources/entities/weather.h \
     sources/environment.h \
+    sources/factoryreset.h \
     sources/filedownload.h \
     sources/fileio.h \
     sources/hardware/batterycharger.h \
@@ -166,6 +167,7 @@ SOURCES += \
     sources/entities/switch.cpp \
     sources/entities/weather.cpp \
     sources/environment.cpp \
+    sources/factoryreset.cpp \
     sources/filedownload.cpp \
     sources/hardware/buttonhandler.cpp \
     sources/hardware/device.cpp \

--- a/remote.pro
+++ b/remote.pro
@@ -259,10 +259,10 @@ linux {
             sources/hardware/linux/arm/displaycontrol_yio.cpp \
             sources/hardware/linux/arm/drv2605.cpp \
             sources/hardware/linux/arm/mcp23017_interrupt.cpp
-
-        # needed for std::filesystem
-        LIBS += -lstdc++fs
     }
+
+    # needed for std::filesystem
+    LIBS += -lstdc++fs
 }
 
 # Android specific files (empty template for now)

--- a/setup/SetupStep9Skip.qml
+++ b/setup/SetupStep9Skip.qml
@@ -67,7 +67,6 @@ Item {
     }
 
     Component.onCompleted: {
-        // delete /firstrun
-        console.debug("Deleting /firstrun success: " + fileio.deleteFile("/firstrun"));
+        config.finishFirstRun()
     }
 }

--- a/setup/SetupStep9Success.qml
+++ b/setup/SetupStep9Success.qml
@@ -67,7 +67,6 @@ Item {
     }
 
     Component.onCompleted: {
-        // delete /firstrun
-        console.debug("Deleting /firstrun success: " + fileio.deleteFile("/firstrun"));
+        config.finishFirstRun()
     }
 }

--- a/sources/commandlinehandler.h
+++ b/sources/commandlinehandler.h
@@ -22,8 +22,8 @@
 
 #pragma once
 
-#include <QObject>
 #include <QCoreApplication>
+#include <QObject>
 
 class CommandLineHandler : public QObject {
     Q_OBJECT
@@ -31,21 +31,20 @@ class CommandLineHandler : public QObject {
  public:
     explicit CommandLineHandler(QObject *parent = nullptr);
 
-    void process(const QCoreApplication &app, const QString &defaultConfigPath);
+    void process(const QCoreApplication &app, const QString &resourcePath, const QString &configurationPath);
 
-    QString getProfile() { return m_profile; }
+    QString getProfile() const { return m_profile; }
 
-    QString configFile() { return m_cfgFile; }
-    QString configSchemaFile() { return m_cfgSchemaFile; }
-    QString hardwareConfigFile() { return m_hwCfgFile; }
-    QString hardwareConfigSchemaFile() { return m_hwCfgSchemaFile; }
+    QString configFile() const { return m_cfgFile; }
+    QString configSchemaFile() const { return m_cfgSchemaFile; }
+    QString hardwareConfigFile() const { return m_hwCfgFile; }
+    QString hardwareConfigSchemaFile() const { return m_hwCfgSchemaFile; }
 
  private:
     bool validateJson(const QString &filePath, const QString &schemaPath);
 
  private:
     QString m_profile;
-    QString m_cfgPath;
     QString m_cfgFile;
     QString m_cfgSchemaFile;
     QString m_hwCfgFile;

--- a/sources/config.cpp
+++ b/sources/config.cpp
@@ -26,8 +26,16 @@
 #include <QJsonDocument>
 #include <QLoggingCategory>
 
+#if defined(Q_OS_LINUX)
+#include <filesystem>
+#endif
+
+#include "environment.h"
+
 static Q_LOGGING_CATEGORY(CLASS_LC, "config");
 
+const QString Config::CFG_FILE_NAME = "config.json";
+const QString Config::CFG_FILE_NAME_DEF = "config.json.def";
 const QString Config::KEY_ID = CFG_KEY_ID;
 const QString Config::KEY_FRIENDLYNAME = CFG_KEY_FRIENDLYNAME;
 const QString Config::KEY_ENTITY_ID = CFG_KEY_ENTITY_ID;
@@ -43,15 +51,18 @@ Config *Config::s_instance = nullptr;
 
 ConfigInterface::~ConfigInterface() {}
 
-Config::Config(QQmlApplicationEngine *engine, QString configFilePath, QString schemaFilePath, QString appPath)
-    : m_engine(engine), m_jsf(configFilePath, schemaFilePath), m_error("") {
+Config::Config(QQmlApplicationEngine *engine, QString configFilePath, QString schemaFilePath, Environment *environment)
+    : m_engine(engine), m_jsf(configFilePath, schemaFilePath), m_error(""), m_environment(environment) {
     Q_ASSERT(engine);
+    Q_ASSERT(environment);
 
     s_instance = this;
 
     // load translations file
-    JsonFile translationCfg(appPath.append(QString("/translations.json")), "");
+    JsonFile translationCfg(environment->getResourcePath().append(QString("/translations.json")), "");
     m_languages = translationCfg.read().toList();
+
+    qCDebug(CLASS_LC) << "Configuration file:" << configFilePath;
 }
 
 Config::~Config() { s_instance = nullptr; }
@@ -158,6 +169,46 @@ QObject *Config::getQMLObject(QList<QObject *> nodes, const QString &name) {
 }
 
 QObject *Config::getQMLObject(const QString &name) { return getQMLObject(m_engine->rootObjects(), name); }
+
+bool Config::resetConfigurationForFirstRun() {
+    qCWarning(CLASS_LC) << "Resetting remote configuration for first run";
+
+    QString defaultConfigFile =
+        qEnvironmentVariable(Environment::ENV_YIO_APP_DIR, m_environment->getResourcePath()) + "/" + CFG_FILE_NAME_DEF;
+
+    if (!QFile::exists(defaultConfigFile)) {
+        qCCritical(CLASS_LC) << "Default config file not found. Cannot restore to defaults.";
+        return false;
+    }
+
+    if (m_environment->isYioRemote()) {
+        QString cfgFile = QString("%1/%2").arg(m_environment->getConfigurationPath()).arg(CFG_FILE_NAME);
+        QString cfgFileBackup = cfgFile + ".old";
+        qCDebug(CLASS_LC) << "Backing up configuration file" << cfgFile
+                          << "and replacing it with default configuration:" << defaultConfigFile;
+#if defined(Q_OS_LINUX)
+        try {
+            // make a copy of existing configuration
+            if (!std::filesystem::copy_file(cfgFile.toStdString(), cfgFileBackup.toStdString(),
+                                            std::filesystem::copy_options::overwrite_existing)) {
+                qCCritical(CLASS_LC) << "Error backing up existing configuration.";
+                return false;
+            }
+
+            if (!std::filesystem::copy_file(defaultConfigFile.toStdString(), cfgFile.toStdString(),
+                                            std::filesystem::copy_options::overwrite_existing)) {
+                qCCritical(CLASS_LC) << "Error copying default configuration.";
+                return false;
+            }
+        } catch (std::exception &e) {
+            qCCritical(CLASS_LC) << "Error resetting configuration:" << qPrintable(e.what());
+            return false;
+        }
+#endif
+    }
+
+    return m_environment->prepareFirstRun();
+}
 
 void Config::setProfileId(QString id) {
     qCDebug(CLASS_LC) << "Profile id changing to:" << id << "from:" << m_cacheProfileId;

--- a/sources/config.h
+++ b/sources/config.h
@@ -28,6 +28,7 @@
 #include <QQmlContext>
 #include <QtDebug>
 
+#include "environment.h"
 #include "jsonfile.h"
 #include "yio-interface/configinterface.h"
 #include "yio-interface/unitsystem.h"
@@ -49,6 +50,8 @@ class Config : public QObject, public ConfigInterface {
     Q_PROPERTY(UnitSystem::Enum unitSystem READ getUnitSystem WRITE setUnitSystem NOTIFY unitSystemChanged)
 
  public:
+    static const QString CFG_FILE_NAME;
+    static const QString CFG_FILE_NAME_DEF;
     // Common configuration keys. Initialized in config.cpp
     // HELP: anyone knows how to properly define "static const QString" constants across Qt plugin boundaries?
     static const QString KEY_ID;
@@ -142,8 +145,25 @@ class Config : public QObject, public ConfigInterface {
 
     QQmlApplicationEngine* getAppEngine() { return m_engine; }
 
+    /**
+     * @brief QML facade for Environment::isFirstRun
+     */
+    Q_INVOKABLE bool isFirstRun() { return m_environment->isFirstRun(); }
+    /**
+     * @brief QML facade for Environment::finishFirstRun().
+     */
+    Q_INVOKABLE bool finishFirstRun() { return m_environment->finishFirstRun(); }
+
+    /**
+     * @brief Resets the configuration and prepares the remote for the initial setup run.
+     * The remote must be rebooted after calling this method.
+     * @return true if successful, false otherwise
+     */
+    bool resetConfigurationForFirstRun();
+
  public:
-    explicit Config(QQmlApplicationEngine* engine, QString configFilePath, QString schemaFilePath, QString appPath);
+    explicit Config(QQmlApplicationEngine* engine, QString configFilePath, QString schemaFilePath,
+                    Environment* environment);
     ~Config() override;
 
     static Config* getInstance() { return s_instance; }
@@ -173,7 +193,7 @@ class Config : public QObject, public ConfigInterface {
     template <class EnumClass>
     EnumClass stringToEnum(const QVariant& enumString, const EnumClass& defaultValue) const {
         const auto metaEnum = QMetaEnum::fromType<EnumClass>();
-        bool ok;
+        bool       ok;
         const auto value = metaEnum.keyToValue(enumString.toString().toUtf8(), &ok);
         return ok ? static_cast<EnumClass>(value) : defaultValue;
     }
@@ -200,4 +220,6 @@ class Config : public QObject, public ConfigInterface {
     QVariantMap      m_cacheUIPages;
     QVariantMap      m_cacheUIGroups;
     UnitSystem::Enum m_cacheUnitSystem = UnitSystem::METRIC;
+
+    Environment* m_environment;
 };

--- a/sources/environment.cpp
+++ b/sources/environment.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright (C) 2020 Foo Bar <foo@bar.com>
+ * Copyright (C) 2020 Markus Zehnder <business@markuszehnder.ch>
  *
  * This file is part of the YIO-Remote software project.
  *
@@ -77,12 +77,24 @@ QString Environment::getConfigurationPath() const {
     return getResourcePath();
 }
 
+QString Environment::getUserStoragePath() const {
+    if (m_yioRemote) {
+        return "/var/yio";
+    }
+
+    // TODO(zehnm) refine storage path for non YIO remote environments
+    return getResourcePath() + "/UserData";
+}
+
 bool Environment::prepareFirstRun() {
     qCDebug(CLASS_LC) << "Creating marker file for first run:" << m_markerFileFirstRun;
 
+    m_error.clear();
+
     QFile file(m_markerFileFirstRun);
     if (!file.open(QIODevice::WriteOnly)) {
-        qCCritical(CLASS_LC) << "Error writing firstrun marker file:" << m_markerFileFirstRun;
+        m_error = "Error writing firstrun marker file: " + m_markerFileFirstRun;
+        qCCritical(CLASS_LC) << m_error;
         return false;
     }
     file.close();

--- a/sources/environment.h
+++ b/sources/environment.h
@@ -37,7 +37,8 @@ class Environment : public QObject {
     static const char* ENV_YIO_APP_DIR;
     static const char* ENV_YIO_OS_VERSION;
     static const char* ENV_YIO_PLUGIN_DIR;
-    static const char* UNKNOWN;
+
+    static const QString UNKNOWN;
 
  public:
     /**
@@ -72,6 +73,30 @@ class Environment : public QObject {
      */
     QString getRemoteOsVersion() const;
 
+    /**
+     * @brief Returns the directory which contains the application resources
+     * @details The application resources are usually stored in the same directory of the application executable.
+     */
+    QString getResourcePath() const;
+    QString getConfigurationPath() const;
+
+    /**
+     * @brief Sets the first run marker for the next startup.
+     * @return True if the operation succeeded, false otherwise.
+     */
+    bool prepareFirstRun();
+
+    /**
+     * @brief Returns true if it's the first run of the remote to start the initial setup.
+     */
+    bool isFirstRun() const;
+
+    /**
+     * @brief Removes the first run marker.
+     * @return True if the operation succeeded, false otherwise.
+     */
+    bool finishFirstRun();
+
  private:
     OS      determineOS();
     QString getRaspberryRevision(OS os);
@@ -82,4 +107,5 @@ class Environment : public QObject {
     OS      m_os;
     bool    m_yioRemote;
     bool    m_raspberryPi;
+    QString m_markerFileFirstRun;
 };

--- a/sources/environment.h
+++ b/sources/environment.h
@@ -79,6 +79,10 @@ class Environment : public QObject {
      */
     QString getResourcePath() const;
     QString getConfigurationPath() const;
+    /**
+     * @brief Returns the path for storing data at runtime
+     */
+    QString getUserStoragePath() const;
 
     /**
      * @brief Sets the first run marker for the next startup.
@@ -97,6 +101,8 @@ class Environment : public QObject {
      */
     bool finishFirstRun();
 
+    QString getError() const { return m_error; }
+
  private:
     OS      determineOS();
     QString getRaspberryRevision(OS os);
@@ -108,4 +114,5 @@ class Environment : public QObject {
     bool    m_yioRemote;
     bool    m_raspberryPi;
     QString m_markerFileFirstRun;
+    QString m_error;
 };

--- a/sources/factoryreset.cpp
+++ b/sources/factoryreset.cpp
@@ -1,0 +1,53 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2020 Markus Zehnder <business@markuszehnder.ch>
+ *
+ * This file is part of the YIO-Remote software project.
+ *
+ * YIO-Remote software is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * YIO-Remote software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with YIO-Remote software. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *****************************************************************************/
+
+#include "factoryreset.h"
+
+#include "config.h"
+#include "hardware/hardwarefactory.h"
+
+FactoryReset::FactoryReset(Environment* environment, QObject* parent) : QObject(parent), m_environment(environment) {}
+
+bool FactoryReset::isSupported() const { return m_environment->isYioRemote(); }
+
+void FactoryReset::performReset() {
+    if (!isSupported()) {
+        emit factoryResetFailed("Not supported on this device.");
+        return;
+    }
+    emit factoryResetStarted();
+
+    Config*          config = Config::getInstance();
+    HardwareFactory* hwFactory = HardwareFactory::instance();
+    QVariantMap      oldCfg = config->getConfig();
+
+    if (config->resetConfigurationForFirstRun()) {
+        // reset wifi settings
+        hwFactory->getWifiControl()->clearConfiguredNetworks();
+        // TODO(zehnm) further clean up like puring log files and user storage
+        emit factoryResetCompleted();
+    } else {
+        QString error = config->getError();
+        config->setConfig(oldCfg);
+        emit factoryResetFailed(error);
+    }
+}

--- a/sources/factoryreset.h
+++ b/sources/factoryreset.h
@@ -1,0 +1,58 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2020 Markus Zehnder <business@markuszehnder.ch>
+ *
+ * This file is part of the YIO-Remote software project.
+ *
+ * YIO-Remote software is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * YIO-Remote software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with YIO-Remote software. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+
+#include "environment.h"
+
+class FactoryReset : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(bool supported READ isSupported CONSTANT)
+    Q_PROPERTY(QString getError READ getError CONSTANT)
+
+ public:
+    explicit FactoryReset(Environment* environment, QObject* parent = nullptr);
+
+    bool    isSupported() const;
+    QString getError() const { return m_error; }
+
+ public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+    void performReset();
+
+ signals:
+    void factoryResetStarted();
+    void factoryResetCompleted();
+
+    /**
+     * @brief This signal is emitted if a download failed.
+     * @param errorMsg A human-readable description of the error
+     */
+    void factoryResetFailed(const QString& errorMsg);
+
+ private:
+    QString m_error;
+
+    Environment* m_environment;
+};

--- a/sources/hardware/buttonhandler.cpp
+++ b/sources/hardware/buttonhandler.cpp
@@ -41,7 +41,7 @@ ButtonHandler::ButtonHandler(InterruptHandler *interruptHandler, YioAPI *api, QO
     connect(m_api, &YioAPI::buttonPressed, this, &ButtonHandler::onYIOAPIPressed);
     connect(m_api, &YioAPI::buttonReleased, this, &ButtonHandler::onYIOAPIReleased);
 
-    qCDebug(CLASS_LC) << "Intialized";
+    qCDebug(CLASS_LC) << "Initialized";
 }
 
 ButtonHandler::~ButtonHandler() { s_instance = nullptr; }

--- a/sources/hardware/linux/arm/mcp23017_handler.h
+++ b/sources/hardware/linux/arm/mcp23017_handler.h
@@ -65,7 +65,7 @@
 
 #define MCP23017_INT_ERR 255
 
-static Q_LOGGING_CATEGORY(CLASS_LC2, "MCP23017");
+static Q_LOGGING_CATEGORY(CLASS_LC2, "hw.dev.MCP23017");
 
 class MCP23017 {
  public:
@@ -122,14 +122,18 @@ class MCP23017 {
         return true;
     }
 
+    /**
+     * @brief Returns true if volume up, top left button (outline circle), and dpad down are pressed together during
+     * startup.
+     */
     bool readReset() {
         // read initial state to determine if reset is needed
-        int gpioB = wiringPiI2CReadReg8(m_i2cFd, MCP23017_GPIOB);
-        if (!(gpioB & 0x040) && !(gpioB & 0x080) && !(gpioB & 0x04)) {
-            return true;
-        } else {
-            return false;
-        }
+        int  gpioB = wiringPiI2CReadReg8(m_i2cFd, MCP23017_GPIOB);
+        bool volUp = !(gpioB & 0x040);
+        bool topLeft = !(gpioB & 0x080);
+        bool dpadDown = !(gpioB & 0x04);
+        qCDebug(CLASS_LC2) << "Reading reset keys [vol up][top left][dpad down]:" << volUp << topLeft << dpadDown;
+        return volUp && topLeft && dpadDown;
     }
 
     int readInterrupt() {

--- a/sources/hardware/linux/arm/mcp23017_interrupt.cpp
+++ b/sources/hardware/linux/arm/mcp23017_interrupt.cpp
@@ -103,6 +103,7 @@ bool Mcp23017InterruptHandler::setupGPIO() {
     connect(notifier, &QFileSystemWatcher::fileChanged, this, &Mcp23017InterruptHandler::interruptHandler);
 
     if (mcp.readReset()) {
+        qCInfo(CLASS_LC) << "Reset keys pressed!";
         m_wasResetPress = true;
     }
 

--- a/sources/hardware/linux/wifi_wpasupplicant.cpp
+++ b/sources/hardware/linux/wifi_wpasupplicant.cpp
@@ -492,7 +492,7 @@ bool WifiWpaSupplicant::controlRequest(const QString& cmd, char* buf, size_t buf
 
     buf[buflen] = '\0';
     if (res < 0) {
-        qCCritical(CLASS_LC) << "wpa_ctrl_request failed for command" << cmd << "with error:" << res;
+        qCCritical(CLASS_LC) << "wpa_ctrl_request failed for command" << cmd << "with error:" << res << strerror(errno);
         return false;
     }
 

--- a/sources/softwareupdate.cpp
+++ b/sources/softwareupdate.cpp
@@ -50,7 +50,7 @@ SoftwareUpdate::SoftwareUpdate(const QVariantMap &cfg, BatteryFuelGauge *battery
       m_appUpdateUrl(cfg.value("updateUrl", "https://update.yio.app/v1/")
                          .toUrl()
                          .resolved(cfg.value("updateUrlAppPath", "app/updates").toUrl())),
-      m_downloadDir(cfg.value("downloadDir", "/tmp/yio").toString()),
+      m_downloadDir(cfg.value("downloadDir", "/var/yio/download").toString()),
       m_appUpdateScript(cfg.value("appUpdateScript", "/opt/yio/scripts/app-update.sh").toString()),
       m_channel(cfg.value("channel", "release").toString()) {
     Q_ASSERT(m_batteryFuelGauge);

--- a/translations/en_US.ts
+++ b/translations/en_US.ts
@@ -713,8 +713,9 @@ to set up YIO remote</source>
 <context>
     <name>QGuiApplication</name>
     <message>
-        <location filename="../sources/main.cpp" line="218"/>
-        <source>An error occured while restoring to defaults. Please try again.</source>
+        <location filename="../sources/main.cpp" line="210"/>
+        <source>Factory reset failed.
+ %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/en_US.ts
+++ b/translations/en_US.ts
@@ -164,22 +164,22 @@ To learn more about the project, visit
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/climate/ui/Card.qml" line="416"/>
+        <location filename="../components/climate/ui/Card.qml" line="420"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/climate/ui/Card.qml" line="426"/>
+        <location filename="../components/climate/ui/Card.qml" line="430"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/climate/ui/Card.qml" line="432"/>
+        <location filename="../components/climate/ui/Card.qml" line="436"/>
         <source>Heat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/climate/ui/Card.qml" line="438"/>
+        <location filename="../components/climate/ui/Card.qml" line="442"/>
         <source>Cool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -383,32 +383,32 @@ To learn more about the project, visit
 <context>
     <name>CommandLineHandler</name>
     <message>
-        <location filename="../sources/commandlinehandler.cpp" line="40"/>
+        <location filename="../sources/commandlinehandler.cpp" line="45"/>
         <source>Use configuration profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/commandlinehandler.cpp" line="43"/>
+        <location filename="../sources/commandlinehandler.cpp" line="48"/>
         <source>Use configuration file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/commandlinehandler.cpp" line="44"/>
+        <location filename="../sources/commandlinehandler.cpp" line="49"/>
         <source>Use configuration schema file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/commandlinehandler.cpp" line="45"/>
+        <location filename="../sources/commandlinehandler.cpp" line="50"/>
         <source>Use hardware configuration file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/commandlinehandler.cpp" line="46"/>
+        <location filename="../sources/commandlinehandler.cpp" line="51"/>
         <source>Use hardware configuration schema file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/commandlinehandler.cpp" line="50"/>
+        <location filename="../sources/commandlinehandler.cpp" line="55"/>
         <source>Validate json configuration files and exit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -713,13 +713,8 @@ to set up YIO remote</source>
 <context>
     <name>QGuiApplication</name>
     <message>
-        <location filename="../sources/main.cpp" line="247"/>
+        <location filename="../sources/main.cpp" line="218"/>
         <source>An error occured while restoring to defaults. Please try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../sources/main.cpp" line="251"/>
-        <source>Default config file not found. Cannot restore to defaults.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -774,59 +769,59 @@ Navigate your internet browser to: http://</source>
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../basic_ui/pages/Settings.qml" line="93"/>
-        <location filename="../basic_ui/pages/Settings.qml" line="106"/>
-        <location filename="../basic_ui/pages/Settings.qml" line="162"/>
+        <location filename="../basic_ui/pages/Settings.qml" line="98"/>
+        <location filename="../basic_ui/pages/Settings.qml" line="111"/>
+        <location filename="../basic_ui/pages/Settings.qml" line="167"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/pages/Settings.qml" line="173"/>
+        <location filename="../basic_ui/pages/Settings.qml" line="178"/>
         <source>New software is available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/pages/Settings.qml" line="173"/>
+        <location filename="../basic_ui/pages/Settings.qml" line="178"/>
         <source>Your software is up to date.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/pages/Settings.qml" line="190"/>
+        <location filename="../basic_ui/pages/Settings.qml" line="195"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/pages/Settings.qml" line="196"/>
+        <location filename="../basic_ui/pages/Settings.qml" line="201"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/pages/Settings.qml" line="209"/>
+        <location filename="../basic_ui/pages/Settings.qml" line="214"/>
         <source>Integrations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/pages/Settings.qml" line="216"/>
+        <location filename="../basic_ui/pages/Settings.qml" line="221"/>
         <source>Battery &amp; power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/pages/Settings.qml" line="223"/>
+        <location filename="../basic_ui/pages/Settings.qml" line="228"/>
         <source>m remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/pages/Settings.qml" line="230"/>
+        <location filename="../basic_ui/pages/Settings.qml" line="235"/>
         <source>WiFi &amp; bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/pages/Settings.qml" line="236"/>
+        <location filename="../basic_ui/pages/Settings.qml" line="241"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../basic_ui/pages/Settings.qml" line="242"/>
+        <location filename="../basic_ui/pages/Settings.qml" line="247"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Refactored all marker file and configuration handling to prepare for read-only root partition:

- Centralized first run handling in Environment and Config classes
- Configuration reset fixes and clean up
- Enabled configuration reset for Linux, not just ARM, for better test-ability
- Created a dedicated factory reset class which can be called from the UI. Part of #505

Part of YIO-Remote/remote-os#49