### PR TITLE
fix: Battery fuelgauge standby handling

### DIFF
--- a/sources/hardware/batteryfuelgauge.h
+++ b/sources/hardware/batteryfuelgauge.h
@@ -39,26 +39,29 @@ class BatteryFuelGauge : public Device {
     Q_PROPERTY(bool isCharging READ getIsCharging NOTIFY isChargingChanged)
 
  public:
-    virtual void    begin()                         = 0;
-    virtual int     getVoltage()                    = 0;
-    virtual int     getFullChargeCapacity()         = 0;
-    virtual int     getAverageCurrent()             = 0;
-    virtual int     getAveragePower()               = 0;
-    virtual int     getStateOfCharge()              = 0;
-    virtual int16_t getInternalTemperatureC()       = 0;  // Result in 0.1 Celsius
-    virtual int     getStateOfHealth()              = 0;
-    virtual int     getFullAvailableCapacity()      = 0;
-    virtual int     getRemainingCapacity()          = 0;
-    virtual int     getDesignCapacity()             = 0;
+    virtual void    begin() = 0;
+    virtual int     getVoltage() = 0;
+    virtual int     getFullChargeCapacity() = 0;
+    virtual int     getAverageCurrent() = 0;
+    virtual int     getAveragePower() = 0;
+    virtual int     getStateOfCharge() = 0;
+    virtual int16_t getInternalTemperatureC() = 0;  // Result in 0.1 Celsius
+    virtual int     getStateOfHealth() = 0;
+    virtual int     getFullAvailableCapacity() = 0;
+    virtual int     getRemainingCapacity() = 0;
+    virtual int     getDesignCapacity() = 0;
     virtual void    changeCapacity(int newCapacity) = 0;
-    virtual int     getLevel()                      = 0;
-    virtual int     getHealth()                     = 0;
-    virtual bool    getIsCharging()                 = 0;
-    virtual float   remainingLife()                 = 0;  // result in hours
+    virtual int     getLevel() = 0;
+    virtual int     getHealth() = 0;
+    virtual bool    getIsCharging() = 0;
+    virtual float   remainingLife() = 0;  // result in hours
 
     void setCapacity(int capacity) { m_capacity = capacity; }
 
     int getCapacity() { return m_capacity; }
+
+ public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+    virtual void updateBatteryValues() = 0;
 
  signals:
     void levelChanged();

--- a/sources/hardware/linux/arm/bq27441.cpp
+++ b/sources/hardware/linux/arm/bq27441.cpp
@@ -29,7 +29,6 @@
 #include <QtDebug>
 
 #include "../../../notifications.h"
-#include "../../../standbycontrol.h"
 #include "QFile"
 
 static Q_LOGGING_CATEGORY(CLASS_LC, "hw.dev.BQ27441");
@@ -49,9 +48,6 @@ BQ27441::BQ27441(InterruptHandler *interruptHandler, int capacity, const QString
             updateBatteryValues();
         }
     });
-
-    StandbyControl *standbyControl = StandbyControl::getInstance();
-    connect(standbyControl, &StandbyControl::standByOff, this, [=]() { updateBatteryValues(); });
 }
 
 BQ27441::~BQ27441() { close(); }

--- a/sources/hardware/linux/arm/bq27441.h
+++ b/sources/hardware/linux/arm/bq27441.h
@@ -117,6 +117,9 @@ class BQ27441 : public BatteryFuelGauge {
     // Extended Data Commands
     uint16_t getOpConfig();
 
+ public slots:
+    void  updateBatteryValues() override;
+
     // Device interface
  public:
     bool open() override;
@@ -146,5 +149,4 @@ class BQ27441 : public BatteryFuelGauge {
     bool  m_isCharging           = false;
     bool  m_wasLowBatteryWarning = false;
     float m_remainingLife        = 0;
-    void  updateBatteryValues();
 };

--- a/sources/hardware/mock/batteryfuelgauge_mock.h
+++ b/sources/hardware/mock/batteryfuelgauge_mock.h
@@ -50,4 +50,7 @@ class BatteryFuelGaugeMock : public BatteryFuelGauge {
     int     getHealth() override { return 100; }
     bool    getIsCharging() override { return false; }  // to test charging screen: return true
     float   remainingLife() override { return 2; }
+
+ public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+    void updateBatteryValues() override {};
 };

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -227,6 +227,8 @@ int main(int argc, char* argv[]) {
                            hwFactory->getBatteryFuelGauge(), config, yioapi, integrations);
     Q_UNUSED(standbyControl);
     qmlRegisterSingletonType<StandbyControl>("StandbyControl", 1, 0, "StandbyControl", &StandbyControl::getQMLInstance);
+    QObject::connect(standbyControl, &StandbyControl::standByOff, hwFactory->getBatteryFuelGauge(),
+                     &BatteryFuelGauge::updateBatteryValues);
 
     // SOFTWARE UPDATE
     QVariantMap     appUpdCfg = config->getSettings().value("softwareupdate").toMap();


### PR DESCRIPTION
Standby-off signal wasn't correctly setup to update battery fuel status due to a circular dependency.
Moved the StandbyControl signal handling out of the battery fuel gauge into the setup of main.