### PR TITLE
Reconnect integrations after wifi connection established

### DIFF
--- a/sources/standbycontrol.cpp
+++ b/sources/standbycontrol.cpp
@@ -179,13 +179,15 @@ void StandbyControl::wakeup() {
 
             m_wifiControl->on();
 
-            QObject::connect(m_wifiControl, &WifiControl::connected, this, [=]() {
+            QObject *context = new QObject(this);
+            QObject::connect(m_wifiControl, &WifiControl::connected, context, [=]() {
                 // connect integrations
                 for (int i = 0; i < m_integrations->list().length(); i++) {
                     IntegrationInterface *integrationObj =
                         qobject_cast<IntegrationInterface *>(m_integrations->list().at(i));
                     integrationObj->connect();
                 }
+                context->deleteLater();
             });
 
             m_displayControl->setMode(DisplayControl::StandbyOff);

--- a/sources/standbycontrol.cpp
+++ b/sources/standbycontrol.cpp
@@ -179,15 +179,17 @@ void StandbyControl::wakeup() {
 
             m_wifiControl->on();
 
+            QObject::connect(m_wifiControl, &WifiControl::connected, this, [=]() {
+                // connect integrations
+                for (int i = 0; i < m_integrations->list().length(); i++) {
+                    IntegrationInterface *integrationObj =
+                        qobject_cast<IntegrationInterface *>(m_integrations->list().at(i));
+                    integrationObj->connect();
+                }
+            });
+
             m_displayControl->setMode(DisplayControl::StandbyOff);
             readAmbientLight();
-
-            // connect integrations
-            for (int i = 0; i < m_integrations->list().length(); i++) {
-                IntegrationInterface *integrationObj =
-                    qobject_cast<IntegrationInterface *>(m_integrations->list().at(i));
-                integrationObj->connect();
-            }
 
             m_api->start();
 


### PR DESCRIPTION
At the moment, after coming out of standby, the wifi is reconnected, but immediately after that the integrations connected too. This more often leads to errors as it takes a couple of seconds for wifi to reconnect. 

The integrations should connect after the wifi connection is established.

The integration connect method is called when the wifiControl connected signal is emitted.