### PR TITLE
Logger rewrite

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,3 +9,6 @@ ColumnLimit: 120
 
 AccessModifierOffset: -3
 AlignConsecutiveDeclarations: true
+
+AllowShortFunctionsOnASingleLine: Inline
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@
         - name: Get artifact version
           run: |
             read -r APP_VERSION < binaries/version.txt
-            echo "::set-env name=APP_VERSION::$APP_VERSION"
+            echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
 
         - name: Upload build artefacts
           uses: actions/upload-artifact@v2
@@ -93,8 +93,8 @@
 
         - name: Get timestamp
           run: |
-            echo "::set-env name=TIMESTAMP::$(date +"%Y%m%d_%H%M%S")"
-  
+            echo "TIMESTAMP=$(date +"%Y%m%d_%H%M%S")" >> $GITHUB_ENV
+
         - name: Create GitHub development build archives
           if: "!contains(github.ref, 'tags/v')"
           run: |

--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -21,7 +21,7 @@ env:
   APP_PRO: remote.pro
   APP_NAME: app
   PROJECT_NAME: remote-software
-  # Build artifact output path. Used to set project specific YIO_BIN env var in 'qt_creator' step.
+  # Build artifact output path. Used to set project specific YIO_BIN env var.
   BIN_OUTPUT_PATH: "binaries"
   DEBUG_OUTPUT: "false"
 
@@ -56,6 +56,7 @@ jobs:
         # history required to determine number of commits since last release tag
         fetch-depth: 0
         path: ${{ env.PROJECT_NAME }}
+
     - name: Fetch all tags to determine version
       run: |
         cd ${{ env.PROJECT_NAME }}
@@ -66,7 +67,11 @@ jobs:
       run: |
         YIO_INTG_LIB_VERSION=$(cat "${GITHUB_WORKSPACE}/${{ env.PROJECT_NAME }}/dependencies.cfg" | awk '/^integrations.library:/{print $2}')
         echo "Required integrations.library: $YIO_INTG_LIB_VERSION"
-        echo "::set-env name=YIO_INTG_LIB_VERSION::$YIO_INTG_LIB_VERSION"
+        echo "YIO_INTG_LIB_VERSION=$YIO_INTG_LIB_VERSION" >> $GITHUB_ENV
+
+    - name: Set build output directory
+      shell: bash
+      run: echo "YIO_BIN=${GITHUB_WORKSPACE}/${BIN_OUTPUT_PATH}" >> $GITHUB_ENV  
 
     - name: Checkout integrations.library
       uses: actions/checkout@v2
@@ -80,6 +85,8 @@ jobs:
       run: |
         sudo apt update
         sudo apt install libavahi-client-dev libgl1-mesa-dev g++-8 libstdc++-8-dev
+        # Qt Creator library path is required for Qt linguist tools. Otherwise we'll get libicui18n.so.56 not found!
+        echo "LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/qtcreator/lib/Qt/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
     - name: Download Qt Creator
       id: qt_creator
@@ -95,20 +102,11 @@ jobs:
             set(qtc_platform "windows_vs2015_64")
           elseif ("${{ matrix.config.environment_script }}" MATCHES "vcvars64.bat")
             set(qtc_platform "windows_msvc2017_x64")
-          elseif ("${{ matrix.config.environment_script }}" MATCHES "vcvars32.bat")
-            set(qtc_platform "windows_msvc2017_x86")
           endif()
         elseif ("${{ runner.os }}" STREQUAL "Linux")
           set(qtc_platform "linux_gcc_64_rhel72")
         elseif ("${{ runner.os }}" STREQUAL "macOS")
           set(qtc_platform "mac_x64")
-        endif()
-
-        # Set YIO_BIN env var for other steps
-        message("::set-env name=YIO_BIN::${qtc_output_directory}")
-        # Qt Creator library path is required for Qt linguist tools. Otherwise we'll get libicui18n.so.56 not found!
-        if ("${{ runner.os }}" STREQUAL "Linux")
-          message("::set-env name=LD_LIBRARY_PATH::$ENV{GITHUB_WORKSPACE}/qtcreator/lib/Qt/lib:$ENV{LD_LIBRARY_PATH}")
         endif()
 
         file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/../downloads" download_dir)
@@ -181,9 +179,6 @@ jobs:
           if ("${{ matrix.config.environment_script }}" MATCHES "vcvars64.bat")
             set(qt_package_name "qt.qt5.${qt_version_dotless}.win64_msvc2017_64")
             set(qt_dir_prefix "${qt_version}/msvc2017_64")
-          elseif ("${{ matrix.config.environment_script }}" MATCHES "vcvars32.bat")
-            set(qt_package_name "qt.qt5.${qt_version_dotless}.win32_msvc2017")
-            set(qt_dir_prefix "${qt_version}/msvc2017")
           else()
           endif()
         elseif ("${{ runner.os }}" STREQUAL "Linux")
@@ -222,11 +217,6 @@ jobs:
         set(package_version ${CMAKE_MATCH_1})
         set(package_suffix ${CMAKE_MATCH_2})
         string(REPLACE "-debug-symbols" "" package_suffix "${package_suffix}")
-
-        # Workaround for CMake's greedy regex
-        if ("${{ matrix.config.environment_script }}" MATCHES "vcvars32.bat")
-          string(REPLACE "X86_64" "X86" package_suffix "${package_suffix}")
-        endif()
 
         file(MAKE_DIRECTORY qt5)
 
@@ -298,7 +288,7 @@ jobs:
     - name: Configure
       shell: cmake -P {0}
       run: |
-        if ("${{ runner.os }}" STREQUAL "Windows" AND NOT "x${{ matrix.config.environment_script }}" STREQUAL "x")
+        if ("${{ runner.os }}" STREQUAL "Windows")
           execute_process(
             COMMAND "${{ matrix.config.environment_script }}" && set
             OUTPUT_FILE environment_script_output.txt
@@ -307,9 +297,6 @@ jobs:
           foreach(line IN LISTS output_lines)
             if (line MATCHES "^([a-zA-Z0-9_-]+)=(.*)$")
               set(ENV{${CMAKE_MATCH_1}} "${CMAKE_MATCH_2}")
-
-              # Set for other steps
-              message("::set-env name=${CMAKE_MATCH_1}::${CMAKE_MATCH_2}")
             endif()
           endforeach()
         endif()
@@ -342,6 +329,12 @@ jobs:
       shell: cmake -P {0}
       run: |
         if ("${{ runner.os }}" STREQUAL "Windows")
+          file(STRINGS environment_script_output.txt output_lines)
+          foreach(line IN LISTS output_lines)
+            if (line MATCHES "^([a-zA-Z0-9_-]+)=(.*)$")
+              set(ENV{${CMAKE_MATCH_1}} "${CMAKE_MATCH_2}")
+            endif()
+          endforeach()
           set(ENV{PATH} "${{ steps.qt.outputs.qt_dir }}/bin/;$ENV{PATH}")
         else()
           set(ENV{PATH} "${{ steps.qt.outputs.qt_dir }}/bin/:$ENV{PATH}")
@@ -371,9 +364,9 @@ jobs:
     - name: Set build artifact name
       shell: bash
       run: |
-        APP_VERSION=$(cat ${{ env.YIO_BIN }}/version.txt | awk '{print $1}')
+        APP_VERSION=$(cat "${{ env.YIO_BIN }}/version.txt" | awk '{print $1}')
         echo "App version: $APP_VERSION"
-        echo "::set-env name=ARTIFACT_NAME::${{ env.APP_NAME }}-$APP_VERSION-Qt${{ env.QT_VERSION }}-${{ matrix.config.artifact }}-${{ matrix.config.build }}"
+        echo "ARTIFACT_NAME=${{ env.APP_NAME }}-$APP_VERSION-Qt${{ env.QT_VERSION }}-${{ matrix.config.artifact }}-${{ matrix.config.build }}" >> $GITHUB_ENV
 
     - uses: actions/upload-artifact@v1
       id: upload_artifact

--- a/.github/workflows/code_guidelines.yml
+++ b/.github/workflows/code_guidelines.yml
@@ -13,12 +13,13 @@ on:
 
 jobs:
   cpplint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
       - run: python -m pip install cpplint
-      - run: sudo update-alternatives --install /usr/bin/python python ${pythonLocation}/bin/python3.8 10
       - name: cpplint
         shell: python
         run: |

--- a/remote.pro
+++ b/remote.pro
@@ -27,6 +27,7 @@ CONFIG += c++17 disable-desktop
 CONFIG += qtquickcompiler
 
 DEFINES += QT_DEPRECATED_WARNINGS
+DEFINES += QT_MESSAGELOGCONTEXT
 
 # === Version and build information ===========================================
 # If built in Buildroot use custom package version, otherwise Git
@@ -144,6 +145,7 @@ HEADERS += \
     sources/jsonfile.h \
     sources/launcher.h \
     sources/logger.h \
+    sources/logging.h \
     sources/softwareupdate.h \
     sources/standbycontrol.h \
     sources/translation.h \
@@ -191,6 +193,7 @@ SOURCES += \
     sources/hardware/touchdetect.cpp \
     sources/integrations/integrations.cpp \
     sources/logger.cpp \
+    sources/logging.cpp \
     sources/main.cpp \
     sources/jsonfile.cpp \
     sources/launcher.cpp \

--- a/sources/bluetooth.cpp
+++ b/sources/bluetooth.cpp
@@ -22,22 +22,20 @@
 
 #include "bluetooth.h"
 
-#include <QLoggingCategory>
 #include <QTimer>
 
+#include "logging.h"
 #include "notifications.h"
 
-static Q_LOGGING_CATEGORY(CLASS_LC, "bluetooth");
-
 BluetoothControl::BluetoothControl(QObject *parent) : QObject(parent) {
-    qCInfo(CLASS_LC) << "Bluetooth starting";
+    qCInfo(lcBluetooth) << "Bluetooth starting";
 
     // if there is a bluetooth device, let's set up some things
     if (m_localDevice.isValid()) {
-        qCDebug(CLASS_LC) << "Bluetooth init OK";
+        qCDebug(lcBluetooth) << "Bluetooth init OK";
 
     } else {
-        qCCritical(CLASS_LC) << "Bluetooth device was not found.";
+        qCCritical(lcBluetooth) << "Bluetooth device was not found.";
         Notifications::getInstance()->add(true, tr("Bluetooth device was not found."));
     }
 }
@@ -45,26 +43,26 @@ BluetoothControl::BluetoothControl(QObject *parent) : QObject(parent) {
 void BluetoothControl::turnOn() {
     if (m_localDevice.hostMode() == QBluetoothLocalDevice::HostPoweredOff) {
         m_localDevice.powerOn();
-        qCDebug(CLASS_LC) << "Bluetooth on";
+        qCDebug(lcBluetooth) << "Bluetooth on";
     }
 }
 
 void BluetoothControl::turnOff() {
     m_localDevice.setHostMode(QBluetoothLocalDevice::HostPoweredOff);
-    qCDebug(CLASS_LC) << "Bluetooth off";
+    qCDebug(lcBluetooth) << "Bluetooth off";
 }
 
 void BluetoothControl::lookForDocks() {
     turnOn();
 
-    qCDebug(CLASS_LC) << "Creating bluetooth discovery agent";
+    qCDebug(lcBluetooth) << "Creating bluetooth discovery agent";
     m_discoveryAgent = new QBluetoothDeviceDiscoveryAgent(this);
 
     QObject::connect(m_discoveryAgent, &QBluetoothDeviceDiscoveryAgent::deviceDiscovered, this,
                      &BluetoothControl::onDeviceDiscovered);
     QObject::connect(m_discoveryAgent, &QBluetoothDeviceDiscoveryAgent::finished, this,
                      &BluetoothControl::onDiscoveryFinished);
-    qCDebug(CLASS_LC) << "Starting Bluetooth discovery...";
+    qCDebug(lcBluetooth) << "Starting Bluetooth discovery...";
     m_discoveryAgent->start();
 }
 
@@ -83,37 +81,37 @@ void BluetoothControl::onDeviceDiscovered(const QBluetoothDeviceInfo &device) {
         QString name = device.name();
 
         emit dockFound(name);
-        qCDebug(CLASS_LC) << "YIO Dock found" << name;
+        qCDebug(lcBluetooth) << "YIO Dock found" << name;
 
         QObject::connect(&m_localDevice, &QBluetoothLocalDevice::pairingFinished, this,
                          &BluetoothControl::onPairingDone);
-        qCDebug(CLASS_LC) << "Pairing requested.";
+        qCDebug(lcBluetooth) << "Pairing requested.";
         m_localDevice.requestPairing(m_dockAddress, QBluetoothLocalDevice::Paired);
     }
 }
 
 void BluetoothControl::onDiscoveryFinished() {
-    qCDebug(CLASS_LC) << "Bluetooth discovery finished.";
+    qCDebug(lcBluetooth) << "Bluetooth discovery finished.";
     if (m_discoveryAgent) {
         m_discoveryAgent->deleteLater();
     }
 }
 
 void BluetoothControl::sendCredentialsToDock(const QString &msg) {
-    qCDebug(CLASS_LC) << "Got the wifi credentials.";
+    qCDebug(lcBluetooth) << "Got the wifi credentials.";
     m_dockMessage = msg;
 }
 
 void BluetoothControl::onDockConnected() {
-    qCDebug(CLASS_LC) << "Open bluetooth socket";
+    qCDebug(lcBluetooth) << "Open bluetooth socket";
     // open bluetooth socket
     m_dockSocket->open(QIODevice::WriteOnly);
 
     // format the message
     QByteArray text = m_dockMessage.toUtf8() + '\n';
-    qCDebug(CLASS_LC) << "Sending message to dock:" << text;
+    qCDebug(lcBluetooth) << "Sending message to dock:" << text;
     m_dockSocket->write(text);
-    qCDebug(CLASS_LC) << "Message sent to dock.";
+    qCDebug(lcBluetooth) << "Message sent to dock.";
 
     QTimer::singleShot(6000, [=]() {
         // close and delete the socket
@@ -129,12 +127,12 @@ void BluetoothControl::onDockConnected() {
 
 void BluetoothControl::onPairingDone(const QBluetoothAddress &address, QBluetoothLocalDevice::Pairing pairing) {
     if (address == m_dockAddress && pairing == QBluetoothLocalDevice::Paired) {
-        qCDebug(CLASS_LC) << "Pairing done.";
+        qCDebug(lcBluetooth) << "Pairing done.";
         m_dockSocket = new QBluetoothSocket(QBluetoothServiceInfo::RfcommProtocol, this);
 
         QObject::connect(m_dockSocket, &QBluetoothSocket::connected, this, &BluetoothControl::onDockConnected);
 
         m_dockSocket->connectToService(m_dockAddress, m_dockServiceUuid);
-        qCDebug(CLASS_LC) << "Connecting to bluetooth service" << m_dockAddress << m_dockServiceUuid;
+        qCDebug(lcBluetooth) << "Connecting to bluetooth service" << m_dockAddress << m_dockServiceUuid;
     }
 }

--- a/sources/commandlinehandler.cpp
+++ b/sources/commandlinehandler.cpp
@@ -23,13 +23,10 @@
 #include "commandlinehandler.h"
 
 #include <QCommandLineParser>
-#include <QLoggingCategory>
-#include <QtDebug>
 
 #include "config.h"
 #include "jsonfile.h"
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "env");
+#include "logging.h"
 
 CommandLineHandler::CommandLineHandler(QObject *parent) : QObject(parent), m_profile(""), m_cfgFile("") {}
 
@@ -105,13 +102,13 @@ void CommandLineHandler::process(const QCoreApplication &app, const QString &res
     }
 
     if (!QFile::exists(m_cfgSchemaFile)) {
-        qCWarning(CLASS_LC)
+        qCWarning(lcEnv)
             << "App configuration schema not found, configuration file will not be validated! Missing file:"
             << m_cfgSchemaFile;
     }
 
     if (!QFile::exists(m_hwCfgSchemaFile)) {
-        qCWarning(CLASS_LC)
+        qCWarning(lcEnv)
             << "Hardware configuration schema not found, configuration file will not be validated! Missing file:"
             << m_hwCfgSchemaFile;
     }

--- a/sources/config.cpp
+++ b/sources/config.cpp
@@ -24,15 +24,13 @@
 #include "config.h"
 
 #include <QJsonDocument>
-#include <QLoggingCategory>
 
 #if defined(Q_OS_LINUX)
 #include <filesystem>
 #endif
 
 #include "environment.h"
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "config");
+#include "logging.h"
 
 const QString Config::CFG_FILE_NAME = "config.json";
 const QString Config::CFG_FILE_NAME_DEF = "config.json.def";
@@ -62,10 +60,12 @@ Config::Config(QQmlApplicationEngine *engine, QString configFilePath, QString sc
     JsonFile translationCfg(environment->getResourcePath().append(QString("/translations.json")), "");
     m_languages = translationCfg.read().toList();
 
-    qCDebug(CLASS_LC) << "Configuration file:" << configFilePath;
+    qCDebug(lcCfg) << "Configuration file:" << configFilePath;
 }
 
-Config::~Config() { s_instance = nullptr; }
+Config::~Config() {
+    s_instance = nullptr;
+}
 
 void Config::setFavorite(const QString &entityId, bool value) {
     QStringList fav = profileFavorites();
@@ -168,45 +168,47 @@ QObject *Config::getQMLObject(QList<QObject *> nodes, const QString &name) {
     return nullptr;
 }
 
-QObject *Config::getQMLObject(const QString &name) { return getQMLObject(m_engine->rootObjects(), name); }
+QObject *Config::getQMLObject(const QString &name) {
+    return getQMLObject(m_engine->rootObjects(), name);
+}
 
 bool Config::resetConfigurationForFirstRun() {
     m_error.clear();
-    qCWarning(CLASS_LC) << "Resetting remote configuration for first run";
+    qCWarning(lcCfg) << "Resetting remote configuration for first run";
 
     QString defaultConfigFile =
         qEnvironmentVariable(Environment::ENV_YIO_APP_DIR, m_environment->getResourcePath()) + "/" + CFG_FILE_NAME_DEF;
 
     if (!QFile::exists(defaultConfigFile)) {
         m_error = "Default config file not found: " + defaultConfigFile;
-        qCCritical(CLASS_LC) << m_error;
+        qCCritical(lcCfg) << m_error;
         return false;
     }
 
     if (m_environment->isYioRemote()) {
         QString cfgFile = QString("%1/%2").arg(m_environment->getConfigurationPath()).arg(CFG_FILE_NAME);
         QString cfgFileBackup = cfgFile + ".old";
-        qCDebug(CLASS_LC) << "Backing up configuration file" << cfgFile
-                          << "and replacing it with default configuration:" << defaultConfigFile;
+        qCDebug(lcCfg) << "Backing up configuration file" << cfgFile
+                       << "and replacing it with default configuration:" << defaultConfigFile;
 #if defined(Q_OS_LINUX)
         try {
             // make a copy of existing configuration
             if (!std::filesystem::copy_file(cfgFile.toStdString(), cfgFileBackup.toStdString(),
                                             std::filesystem::copy_options::overwrite_existing)) {
                 m_error = "Error backing up existing configuration.";
-                qCCritical(CLASS_LC) << m_error;
+                qCCritical(lcCfg) << m_error;
                 return false;
             }
 
             if (!std::filesystem::copy_file(defaultConfigFile.toStdString(), cfgFile.toStdString(),
                                             std::filesystem::copy_options::overwrite_existing)) {
                 m_error = "Error copying default configuration.";
-                qCCritical(CLASS_LC) << m_error;
+                qCCritical(lcCfg) << m_error;
                 return false;
             }
         } catch (std::exception &e) {
             m_error = QString("Error resetting configuration: %1").arg(qPrintable(e.what()));
-            qCCritical(CLASS_LC) << m_error;
+            qCCritical(lcCfg) << m_error;
             return false;
         }
 #endif
@@ -220,7 +222,7 @@ bool Config::resetConfigurationForFirstRun() {
 }
 
 void Config::setProfileId(QString id) {
-    qCDebug(CLASS_LC) << "Profile id changing to:" << id << "from:" << m_cacheProfileId;
+    qCDebug(lcCfg) << "Profile id changing to:" << id << "from:" << m_cacheProfileId;
     m_cacheProfileId = id;
     m_cacheUIProfile = m_cacheUIProfiles[m_cacheProfileId].toMap();
 

--- a/sources/config.h
+++ b/sources/config.h
@@ -26,7 +26,6 @@
 #include <QObject>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
-#include <QtDebug>
 
 #include "environment.h"
 #include "jsonfile.h"

--- a/sources/entities/blind.cpp
+++ b/sources/entities/blind.cpp
@@ -22,7 +22,6 @@
 
 #include "blind.h"
 #include <QQmlApplicationEngine>
-#include <QtDebug>
 
 BlindInterface::~BlindInterface() {}
 

--- a/sources/entities/entity.cpp
+++ b/sources/entities/entity.cpp
@@ -25,6 +25,7 @@
 #include <QTimer>
 
 #include "../config.h"
+#include "../logging.h"
 
 EntityInterface::~EntityInterface() {}
 
@@ -198,7 +199,7 @@ void Entity::initializeSupportedFeatures(const QVariantMap& config) {
     for (int i = 0; i < features.length(); i++) {
         int feature = getFeatureIndex(features[i]);
         if (feature < 0) {
-            qWarning() << "not defined feature" << features[i];
+            qCWarning(lcEntity) << "not defined feature" << features[i];
             continue;
         }
         int byte = feature / 8;

--- a/sources/entities/light.cpp
+++ b/sources/entities/light.cpp
@@ -23,7 +23,6 @@
 #include "light.h"
 
 #include <QQmlApplicationEngine>
-#include <QtDebug>
 
 LightInterface::~LightInterface() {}
 

--- a/sources/entities/mediaplayer.cpp
+++ b/sources/entities/mediaplayer.cpp
@@ -21,7 +21,6 @@
  *****************************************************************************/
 
 #include <QQmlApplicationEngine>
-#include <QtDebug>
 
 #include "entities.h"
 #include "mediaplayer.h"

--- a/sources/entities/remote.cpp
+++ b/sources/entities/remote.cpp
@@ -24,8 +24,8 @@
 
 #include <QJsonArray>
 #include <QTimer>
-#include <QtDebug>
 
+#include "../logging.h"
 #include "../yioapi.h"
 
 RemoteInterface::~RemoteInterface() {}
@@ -38,84 +38,144 @@ QMetaEnum Remote::s_metaEnumState;
 
 void Remote::staticInitialize() {
     if (!s_metaEnumAttr.isValid()) {
-        int index          = RemoteDef::staticMetaObject.indexOfEnumerator("Attributes");
-        s_metaEnumAttr     = RemoteDef::staticMetaObject.enumerator(index);
-        index              = RemoteDef::staticMetaObject.indexOfEnumerator("States");
-        s_metaEnumState    = RemoteDef::staticMetaObject.enumerator(index);
-        index              = RemoteDef::staticMetaObject.indexOfEnumerator("Features");
+        int index = RemoteDef::staticMetaObject.indexOfEnumerator("Attributes");
+        s_metaEnumAttr = RemoteDef::staticMetaObject.enumerator(index);
+        index = RemoteDef::staticMetaObject.indexOfEnumerator("States");
+        s_metaEnumState = RemoteDef::staticMetaObject.enumerator(index);
+        index = RemoteDef::staticMetaObject.indexOfEnumerator("Features");
         s_metaEnumFeatures = RemoteDef::staticMetaObject.enumerator(index);
-        index              = RemoteDef::staticMetaObject.indexOfEnumerator("Commands");
+        index = RemoteDef::staticMetaObject.indexOfEnumerator("Commands");
         s_metaEnumCommands = RemoteDef::staticMetaObject.enumerator(index);
         qmlRegisterUncreatableType<RemoteDef>("Entity.Remote", 1, 0, "Remote", "Not creatable as it is an enum type.");
     }
 }
 
 // transport and media controls
-void Remote::play() { command(RemoteDef::C_PLAY, ""); }
+void Remote::play() {
+    command(RemoteDef::C_PLAY, "");
+}
 
-void Remote::pause() { command(RemoteDef::C_PAUSE, ""); }
+void Remote::pause() {
+    command(RemoteDef::C_PAUSE, "");
+}
 
-void Remote::playToggle() { command(RemoteDef::C_PLAYTOGGLE, ""); }
+void Remote::playToggle() {
+    command(RemoteDef::C_PLAYTOGGLE, "");
+}
 
-void Remote::stop() { command(RemoteDef::C_STOP, ""); }
+void Remote::stop() {
+    command(RemoteDef::C_STOP, "");
+}
 
-void Remote::forward() { command(RemoteDef::C_FORWARD, ""); }
+void Remote::forward() {
+    command(RemoteDef::C_FORWARD, "");
+}
 
-void Remote::backward() { command(RemoteDef::C_BACKWARD, ""); }
+void Remote::backward() {
+    command(RemoteDef::C_BACKWARD, "");
+}
 
-void Remote::next() { command(RemoteDef::C_NEXT, ""); }
+void Remote::next() {
+    command(RemoteDef::C_NEXT, "");
+}
 
-void Remote::previous() { command(RemoteDef::C_PREVIOUS, ""); }
+void Remote::previous() {
+    command(RemoteDef::C_PREVIOUS, "");
+}
 
-void Remote::info() { command(RemoteDef::C_INFO, ""); }
+void Remote::info() {
+    command(RemoteDef::C_INFO, "");
+}
 
-void Remote::recordings() { command(RemoteDef::C_RECORDINGS, ""); }
+void Remote::recordings() {
+    command(RemoteDef::C_RECORDINGS, "");
+}
 
-void Remote::record() { command(RemoteDef::C_RECORD, ""); }
+void Remote::record() {
+    command(RemoteDef::C_RECORD, "");
+}
 
-void Remote::live() { command(RemoteDef::C_LIVE, ""); }
+void Remote::live() {
+    command(RemoteDef::C_LIVE, "");
+}
 
 // navigation
-void Remote::cursorUp() { command(RemoteDef::C_CURSOR_UP, ""); }
+void Remote::cursorUp() {
+    command(RemoteDef::C_CURSOR_UP, "");
+}
 
-void Remote::cursorDown() { command(RemoteDef::C_CURSOR_DOWN, ""); }
+void Remote::cursorDown() {
+    command(RemoteDef::C_CURSOR_DOWN, "");
+}
 
-void Remote::cursorLeft() { command(RemoteDef::C_CURSOR_LEFT, ""); }
+void Remote::cursorLeft() {
+    command(RemoteDef::C_CURSOR_LEFT, "");
+}
 
-void Remote::cursorRight() { command(RemoteDef::C_CURSOR_RIGHT, ""); }
+void Remote::cursorRight() {
+    command(RemoteDef::C_CURSOR_RIGHT, "");
+}
 
-void Remote::cursorOK() { command(RemoteDef::C_CURSOR_OK, ""); }
+void Remote::cursorOK() {
+    command(RemoteDef::C_CURSOR_OK, "");
+}
 
-void Remote::back() { command(RemoteDef::C_BACK, ""); }
+void Remote::back() {
+    command(RemoteDef::C_BACK, "");
+}
 
-void Remote::home() { command(RemoteDef::C_HOME, ""); }
+void Remote::home() {
+    command(RemoteDef::C_HOME, "");
+}
 
-void Remote::menu() { command(RemoteDef::C_MENU, ""); }
+void Remote::menu() {
+    command(RemoteDef::C_MENU, "");
+}
 
-void Remote::exit() { command(RemoteDef::C_EXIT, ""); }
+void Remote::exit() {
+    command(RemoteDef::C_EXIT, "");
+}
 
-void Remote::app() { command(RemoteDef::C_APP, ""); }
+void Remote::app() {
+    command(RemoteDef::C_APP, "");
+}
 
 // power commands
-void Remote::powerOn() { command(RemoteDef::C_POWER_ON, ""); }
+void Remote::powerOn() {
+    command(RemoteDef::C_POWER_ON, "");
+}
 
-void Remote::powerOff() { command(RemoteDef::C_POWER_OFF, ""); }
+void Remote::powerOff() {
+    command(RemoteDef::C_POWER_OFF, "");
+}
 
-void Remote::powerToggle() { command(RemoteDef::C_POWER_TOGGLE, ""); }
+void Remote::powerToggle() {
+    command(RemoteDef::C_POWER_TOGGLE, "");
+}
 
 // tuner commands
-void Remote::channelUp() { command(RemoteDef::C_CHANNEL_UP, ""); }
+void Remote::channelUp() {
+    command(RemoteDef::C_CHANNEL_UP, "");
+}
 
-void Remote::channelDown() { command(RemoteDef::C_CHANNEL_DOWN, ""); }
+void Remote::channelDown() {
+    command(RemoteDef::C_CHANNEL_DOWN, "");
+}
 
-void Remote::channelSearch() { command(RemoteDef::C_CHANNEL_SEARCH, ""); }
+void Remote::channelSearch() {
+    command(RemoteDef::C_CHANNEL_SEARCH, "");
+}
 
-void Remote::toFavorite() { command(RemoteDef::C_FAVORITE, ""); }
+void Remote::toFavorite() {
+    command(RemoteDef::C_FAVORITE, "");
+}
 
-void Remote::guide() { command(RemoteDef::C_GUIDE, ""); }
+void Remote::guide() {
+    command(RemoteDef::C_GUIDE, "");
+}
 
 void Remote::channel(int ch) {
-    qCDebug(m_log) << "Switching channel to" << ch;
+    qCDebug(lcEntityRemote) << "Switching channel to" << ch;
     int delay = settings().value("delay").toInt();
 
     QString chStr = QString::number(ch);
@@ -168,14 +228,22 @@ void Remote::channel(int ch) {
     }
 }
 
-void Remote::source() { command(RemoteDef::C_SOURCE, ""); }
+void Remote::source() {
+    command(RemoteDef::C_SOURCE, "");
+}
 
 // volume commands
-void Remote::volumeUp() { command(RemoteDef::C_VOLUME_UP, ""); }
+void Remote::volumeUp() {
+    command(RemoteDef::C_VOLUME_UP, "");
+}
 
-void Remote::volumeDown() { command(RemoteDef::C_VOLUME_DOWN, ""); }
+void Remote::volumeDown() {
+    command(RemoteDef::C_VOLUME_DOWN, "");
+}
 
-void Remote::muteToggle() { command(RemoteDef::C_MUTE_TOGGLE, ""); }
+void Remote::muteToggle() {
+    command(RemoteDef::C_MUTE_TOGGLE, "");
+}
 
 bool Remote::supportsOn() {
     if (isSupported(RemoteDef::F_POWER_ON) && isSupported(RemoteDef::F_POWER_OFF)) {
@@ -185,18 +253,20 @@ bool Remote::supportsOn() {
     }
 }
 
-bool Remote::isOn() { return m_state == RemoteDef::ONLINE; }
+bool Remote::isOn() {
+    return m_state == RemoteDef::ONLINE;
+}
 
-Remote::Remote(QObject* parent) : Entity(Type, QVariantMap(), nullptr, parent), m_log("remote entity") {}
+Remote::Remote(QObject* parent) : Entity(Type, QVariantMap(), nullptr, parent) {}
 
 Remote::Remote(const QVariantMap& config, IntegrationInterface* integrationObj, QObject* parent)
-    : Entity(Type, config, integrationObj, parent), m_log("remote entity") {
+    : Entity(Type, config, integrationObj, parent) {
     staticInitialize();
 
-    m_enumAttr     = &s_metaEnumAttr;
+    m_enumAttr = &s_metaEnumAttr;
     m_enumFeatures = &s_metaEnumFeatures;
     m_enumCommands = &s_metaEnumCommands;
-    m_enumState    = &s_metaEnumState;
+    m_enumState = &s_metaEnumState;
 
     m_specificInterface = qobject_cast<RemoteInterface*>(this);
     initializeSupportedFeatures(config);

--- a/sources/entities/remote.h
+++ b/sources/entities/remote.h
@@ -25,7 +25,6 @@
 #include <QString>
 #include <QVariant>
 
-#include "../logger.h"
 #include "entity.h"
 #include "yio-interface/entities/remoteinterface.h"
 
@@ -113,6 +112,4 @@ class Remote : public Entity, RemoteInterface {
     QVariantList m_commands;
     QVariantList m_channels;
     QVariantMap  m_settings;
-
-    QLoggingCategory m_log;
 };

--- a/sources/environment.cpp
+++ b/sources/environment.cpp
@@ -23,13 +23,13 @@
 #include "environment.h"
 
 #include <QCoreApplication>
-#include <QDebug>
 #include <QFile>
 #include <QFileInfo>
-#include <QLoggingCategory>
 #include <QStorageInfo>
 #include <QSysInfo>
 #include <QTextStream>
+
+#include "logging.h"
 
 const char *Environment::ENV_YIO_HOME = "YIO_HOME";
 const char *Environment::ENV_YIO_APP_DIR = "YIO_APP_DIR";
@@ -37,8 +37,6 @@ const char *Environment::ENV_YIO_OS_VERSION = "YIO_OS_VERSION";
 const char *Environment::ENV_YIO_PLUGIN_DIR = "YIO_PLUGIN_DIR";
 
 const QString Environment::UNKNOWN = "UNKNOWN";
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "env");
 
 Environment::Environment(QObject *parent) : QObject(parent), m_markerFileFirstRun("/firstrun") {
     m_os = determineOS();
@@ -54,11 +52,13 @@ Environment::Environment(QObject *parent) : QObject(parent), m_markerFileFirstRu
         }
     }
 
-    qCDebug(CLASS_LC) << "Device type:" << m_deviceType << "RPi revision:" << rpiRevision
-                      << "YIO remote:" << m_yioRemote << "First run marker file:" << m_markerFileFirstRun;
+    qCDebug(lcEnv) << "Device type:" << m_deviceType << "RPi revision:" << rpiRevision << "YIO remote:" << m_yioRemote
+                   << "First run marker file:" << m_markerFileFirstRun;
 }
 
-QString Environment::getRemoteOsVersion() const { return qEnvironmentVariable(ENV_YIO_OS_VERSION, UNKNOWN); }
+QString Environment::getRemoteOsVersion() const {
+    return qEnvironmentVariable(ENV_YIO_OS_VERSION, UNKNOWN);
+}
 
 QString Environment::getResourcePath() const {
     QString appPath = QCoreApplication::applicationDirPath();
@@ -87,14 +87,14 @@ QString Environment::getUserStoragePath() const {
 }
 
 bool Environment::prepareFirstRun() {
-    qCDebug(CLASS_LC) << "Creating marker file for first run:" << m_markerFileFirstRun;
+    qCDebug(lcEnv) << "Creating marker file for first run:" << m_markerFileFirstRun;
 
     m_error.clear();
 
     QFile file(m_markerFileFirstRun);
     if (!file.open(QIODevice::WriteOnly)) {
         m_error = "Error writing firstrun marker file: " + m_markerFileFirstRun;
-        qCCritical(CLASS_LC) << m_error;
+        qCCritical(lcEnv) << m_error;
         return false;
     }
     file.close();
@@ -103,12 +103,12 @@ bool Environment::prepareFirstRun() {
 
 bool Environment::isFirstRun() const {
     bool firstRun = QFile::exists(m_markerFileFirstRun);
-    qCDebug(CLASS_LC) << "First run:" << firstRun;
+    qCDebug(lcEnv) << "First run:" << firstRun;
     return firstRun;
 }
 
 bool Environment::finishFirstRun() {
-    qCDebug(CLASS_LC) << "First run finished, removing marker file:" << m_markerFileFirstRun;
+    qCDebug(lcEnv) << "First run finished, removing marker file:" << m_markerFileFirstRun;
     return QFile::remove(m_markerFileFirstRun);
 }
 
@@ -153,10 +153,10 @@ QString Environment::getRaspberryRevision(OS os) {
         }
         cpuinfo.close();
     } else {
-        qCDebug(CLASS_LC) << "Error opening /proc/cpuinfo:" << cpuinfo.errorString();
+        qCDebug(lcEnv) << "Error opening /proc/cpuinfo:" << cpuinfo.errorString();
     }
 
-    qCDebug(CLASS_LC) << "cpuinfo: hardware=" << hardware << "revision=" << revision;
+    qCDebug(lcEnv) << "cpuinfo: hardware=" << hardware << "revision=" << revision;
 
     // TODO(zehnm) is this really required? Or is RPi always BCM2835? Looks like a kernel thing...
     if (hardware.contains(QRegExp("(BCM2835|BCM2836|BCM2837|BCM2838|BCM2711|BCM2708|BCM2709)"))) {
@@ -168,7 +168,7 @@ QString Environment::getRaspberryRevision(OS os) {
 
 bool Environment::runningOnYioRemote(const QString &rpiRevision) {
     if (qEnvironmentVariableIsSet("I_AM_YIO")) {
-        qCInfo(CLASS_LC) << "Magic env variable set: we are now a YIO remote!";
+        qCInfo(lcEnv) << "Magic env variable set: we are now a YIO remote!";
         return true;
     }
 

--- a/sources/hardware/buttonhandler.cpp
+++ b/sources/hardware/buttonhandler.cpp
@@ -22,10 +22,7 @@
 
 #include "buttonhandler.h"
 
-#include <QLoggingCategory>
-#include <QtDebug>
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "hw.buttonhandler");
+#include "../logging.h"
 
 ButtonHandler *ButtonHandler::s_instance = nullptr;
 
@@ -41,7 +38,7 @@ ButtonHandler::ButtonHandler(InterruptHandler *interruptHandler, YioAPI *api, QO
     connect(m_api, &YioAPI::buttonPressed, this, &ButtonHandler::onYIOAPIPressed);
     connect(m_api, &YioAPI::buttonReleased, this, &ButtonHandler::onYIOAPIReleased);
 
-    qCDebug(CLASS_LC) << "Initialized";
+    qCDebug(lcBtnHandler) << "Initialized";
 }
 
 ButtonHandler::~ButtonHandler() { s_instance = nullptr; }

--- a/sources/hardware/device.cpp
+++ b/sources/hardware/device.cpp
@@ -22,10 +22,7 @@
 
 #include "device.h"
 
-#include <QLoggingCategory>
-#include <QtDebug>
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "hw.dev.device");
+#include "../logging.h"
 
 Device::Device(QString name, QObject *parent) : QObject(parent), m_open(false), m_name(name) {}
 
@@ -63,5 +60,5 @@ QString Device::errorString() const { return m_errorString; }
 void Device::setErrorString(const QString &str) { m_errorString = str; }
 
 const QLoggingCategory &Device::logCategory() const {
-    return CLASS_LC();
+    return lcDevice();
 }

--- a/sources/hardware/device.h
+++ b/sources/hardware/device.h
@@ -25,6 +25,8 @@
 #include <QIODevice>
 #include <QObject>
 
+#include "../logging.h"
+
 // debug macro from https://stackoverflow.com/a/1644898
 #ifdef QT_DEBUG
 #define DEBUG_TEST 1
@@ -34,12 +36,12 @@
 
 // ASSERT_DEVICE_OPEN is a safety check if the device is really open.
 // It should only be used where it is expected that the device is open and
-// MAY NOT be used where it's possible that the device might be closed!
+// MAY NOT be used where it's possible that the device could be closed!
 #define ASSERT_DEVICE_OPEN(retVal) \
     do { \
       if (DEBUG_TEST) { \
         if (!isOpen()) { \
-            qCWarning(CLASS_LC) << DBG_WARN_DEVICE_CLOSED; \
+            qCWarning(logCategory()) << DBG_WARN_DEVICE_CLOSED; \
             return retVal; \
         } \
       } \

--- a/sources/hardware/hardwarefactory.cpp
+++ b/sources/hardware/hardwarefactory.cpp
@@ -22,7 +22,6 @@
 
 #include "hardwarefactory.h"
 
-#include <QLoggingCategory>
 #include <QtDebug>
 
 #include "../config.h"
@@ -46,8 +45,6 @@
 #include "hardwarefactory_default.h"
 #endif
 
-static Q_LOGGING_CATEGORY(CLASS_LC, "hw.factory");
-
 HardwareFactory *HardwareFactory::s_instance = nullptr;
 
 HardwareFactory::HardwareFactory(QObject *parent) : QObject(parent) {}
@@ -69,7 +66,7 @@ HardwareFactory *HardwareFactory::build(const QString &configFileName, const QSt
         // FIXME decide how to proceed:
         // a) use an empty configuration for build to use default values
         // b) return null and let caller handle this as a fatal error.
-        qCCritical(CLASS_LC).noquote() << "Invalid hardware configuration!"
+        qCCritical(lcHwFactory).noquote() << "Invalid hardware configuration!"
                                        << "Ignoring configuration file and using default values. Errors:" << endl
                                        << hwCfg.error();
         config.clear();
@@ -79,7 +76,7 @@ HardwareFactory *HardwareFactory::build(const QString &configFileName, const QSt
 
 HardwareFactory *HardwareFactory::build(const QVariantMap &config, const QString &profile) {
     if (s_instance != nullptr) {
-        qCCritical(CLASS_LC)
+        qCCritical(lcHwFactory)
             << "BUG ALERT: Invalid program flow! HardwareFactory already initialized, ignoring build() call.";
         return s_instance;
     }

--- a/sources/hardware/hardwarefactory.h
+++ b/sources/hardware/hardwarefactory.h
@@ -25,6 +25,7 @@
 #include <QObject>
 #include <QQmlApplicationEngine>
 
+#include "../logging.h"
 #include "batterycharger.h"
 #include "batteryfuelgauge.h"
 #include "displaycontrol.h"

--- a/sources/hardware/hardwarefactory_default.cpp
+++ b/sources/hardware/hardwarefactory_default.cpp
@@ -22,7 +22,6 @@
 
 #include "hardwarefactory_default.h"
 
-#include <QLoggingCategory>
 #include <QtDebug>
 
 #include "../notifications.h"
@@ -38,8 +37,6 @@
 #include "mock/systemservice_mock.h"
 #include "mock/webserver_mock.h"
 #include "mock/wifi_mock.h"
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "hw.factory");
 
 HardwareFactoryDefault::HardwareFactoryDefault(QObject *parent)
     : HardwareFactory(parent),
@@ -100,61 +97,61 @@ bool HardwareFactoryDefault::buildDevices(const QVariantMap &config) {
 // Dummy default implementations of all devices.
 // They may also be used by concrete sub factories needing a default implementation of a driver.
 WifiControl *HardwareFactoryDefault::dummyWifiControl() {
-    qCDebug(CLASS_LC) << "Using WifiMock";
+    qCDebug(lcHwFactory) << "Using WifiMock";
     return new WifiMock(this);
 }
 
 SystemService *HardwareFactoryDefault::dummySystemService() {
-    qCDebug(CLASS_LC) << "Using SystemServiceMock";
+    qCDebug(lcHwFactory) << "Using SystemServiceMock";
     return new SystemServiceMock(this);
 }
 
 WebServerControl *HardwareFactoryDefault::dummyWebServerControl() {
-    qCDebug(CLASS_LC) << "Using WebServerMock";
+    qCDebug(lcHwFactory) << "Using WebServerMock";
     return new WebServerMock(this);
 }
 
 DisplayControl *HardwareFactoryDefault::dummyDisplayControl() {
-    qCDebug(CLASS_LC) << "Using DisplayControlMock";
+    qCDebug(lcHwFactory) << "Using DisplayControlMock";
     return new DisplayControlMock(this);
 }
 
 BatteryCharger *HardwareFactoryDefault::dummyBatteryCharger() {
-    qCDebug(CLASS_LC) << "Using BatteryChargerMock";
+    qCDebug(lcHwFactory) << "Using BatteryChargerMock";
     return new BatteryChargerMock(this);
 }
 
 BatteryFuelGauge *HardwareFactoryDefault::dummyBatteryFuelGauge() {
-    qCDebug(CLASS_LC) << "Using BatteryFuelGaugeMock";
+    qCDebug(lcHwFactory) << "Using BatteryFuelGaugeMock";
     return new BatteryFuelGaugeMock(this);
 }
 
 InterruptHandler *HardwareFactoryDefault::dummyInterruptHandler() {
-    qCDebug(CLASS_LC) << "Using InterruptHandlerMock";
+    qCDebug(lcHwFactory) << "Using InterruptHandlerMock";
     return new InterruptHandlerMock(this);
 }
 
 HapticMotor *HardwareFactoryDefault::dummyHapticMotor() {
-    qCDebug(CLASS_LC) << "Using HapticMotorMock";
+    qCDebug(lcHwFactory) << "Using HapticMotorMock";
     return new HapticMotorMock(this);
 }
 
 GestureSensor *HardwareFactoryDefault::dummyGestureSensor() {
-    qCDebug(CLASS_LC) << "Using GestureSensorMock";
+    qCDebug(lcHwFactory) << "Using GestureSensorMock";
     return new GestureSensorMock(this);
 }
 
 LightSensor *HardwareFactoryDefault::dummyLightSensor() {
-    qCDebug(CLASS_LC) << "Using LightSensorMock";
+    qCDebug(lcHwFactory) << "Using LightSensorMock";
     return new LightSensorMock(this);
 }
 
 ProximitySensor *HardwareFactoryDefault::dummyProximitySensor() {
-    qCDebug(CLASS_LC) << "Using ProximitySensorMock";
+    qCDebug(lcHwFactory) << "Using ProximitySensorMock";
     return new ProximitySensorMock(this);
 }
 
 SystemInfo *HardwareFactoryDefault::dummySystemInformation() {
-    qCDebug(CLASS_LC) << "Using SystemInformationMock";
+    qCDebug(lcHwFactory) << "Using SystemInformationMock";
     return new SystemInformationMock(this);
 }

--- a/sources/hardware/linux/arm/apds9960.cpp
+++ b/sources/hardware/linux/arm/apds9960.cpp
@@ -28,36 +28,36 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  *****************************************************************************/
 
-#include <QLoggingCategory>
-#include <QtDebug>
+#include "apds9960.h"
 
 #include <unistd.h>
 
+#include <QtDebug>
+
 #include "../../device.h"
 #include "../../proximitysensor.h"
-#include "apds9960.h"
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "hw.dev.APDS9960");
 
 APDS9960::APDS9960(const QString &i2cDevice, int i2cDeviceId, QObject *parent)
     : Device("APDS9960 sensor", parent), m_i2cDevice(i2cDevice), m_i2cDeviceId(i2cDeviceId), m_i2cFd(0) {
     Q_ASSERT(!i2cDevice.isEmpty());
     Q_ASSERT(i2cDeviceId);
-    qCDebug(CLASS_LC()) << name() << i2cDevice << "with id:" << i2cDeviceId;
+    qCDebug(lcApds9960) << name() << i2cDevice << "with id:" << i2cDeviceId;
 }
 
-APDS9960::~APDS9960() { close(); }
+APDS9960::~APDS9960() {
+    close();
+}
 
 bool APDS9960::open() {
     if (isOpen()) {
-        qCWarning(CLASS_LC) << DBG_WARN_DEVICE_OPEN;
+        qCWarning(lcApds9960) << DBG_WARN_DEVICE_OPEN;
         return true;
     }
 
     bool initialized = false;
     m_i2cFd = wiringPiI2CSetupInterface(qPrintable(m_i2cDevice), m_i2cDeviceId);
     if (m_i2cFd == -1) {
-        qCCritical(CLASS_LC) << "Unable to open or select I2C device" << m_i2cDeviceId << "on" << m_i2cDevice;
+        qCCritical(lcApds9960) << "Unable to open or select I2C device" << m_i2cDeviceId << "on" << m_i2cDevice;
     } else {
         uint8_t x = uint8_t(wiringPiI2CReadReg8(m_i2cFd, APDS9960_ID));
         if (x == 0xAB) {
@@ -84,7 +84,9 @@ void APDS9960::close() {
     }
 }
 
-const QLoggingCategory &APDS9960::logCategory() const { return CLASS_LC(); }
+const QLoggingCategory &APDS9960::logCategory() const {
+    return lcApds9960();
+}
 
 void APDS9960::enable(bool en) {
     ASSERT_DEVICE_OPEN()
@@ -282,7 +284,7 @@ uint8_t APDS9960::readProximity() {
 
 bool APDS9960::gestureValid() {
     if (!isOpen()) {
-        qCWarning(CLASS_LC) << DBG_WARN_DEVICE_CLOSED;
+        qCWarning(lcApds9960) << DBG_WARN_DEVICE_CLOSED;
         return false;
     }
 

--- a/sources/hardware/linux/arm/apds9960gesture.h
+++ b/sources/hardware/linux/arm/apds9960gesture.h
@@ -49,6 +49,12 @@ class Apds9960GestureSensor : public GestureSensor {
 
     Gesture gesture() const override { return m_gesture; }
 
+    // Device interface
+ protected:
+    const QLoggingCategory& logCategory() const override {
+        return lcApds9960Gesture();
+    }
+
  private:
     APDS9960* p_apds;
     Gesture   m_gesture;

--- a/sources/hardware/linux/arm/apds9960light.cpp
+++ b/sources/hardware/linux/arm/apds9960light.cpp
@@ -23,15 +23,12 @@
 
 #include "apds9960light.h"
 
-#include <QLoggingCategory>
 #include <QtDebug>
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "hw.dev.APDS9960.light");
 
 Apds9960LightSensor::Apds9960LightSensor(APDS9960 *apds, QObject *parent)
     : LightSensor("APDS9960 light sensor", parent), p_apds(apds) {
     Q_ASSERT(apds);
-    qCDebug(CLASS_LC) << name();
+    qCDebug(lcApds9960Light) << name();
 }
 
 int Apds9960LightSensor::readAmbientLight() {
@@ -43,14 +40,16 @@ int Apds9960LightSensor::readAmbientLight() {
         m_ambientLight = p_apds->getAmbientLight();
         p_apds->getColorData(&m_r, &m_g, &m_b, &m_c);
 
-        qCDebug(CLASS_LC) << "Ambientlight:" << m_ambientLight;
-        qCDebug(CLASS_LC) << "Lux:" << calculateIlluminance(m_r, m_g, m_b);  // not really precise
+        qCDebug(lcApds9960Light) << "Ambientlight:" << m_ambientLight;
+        qCDebug(lcApds9960Light) << "Lux:" << calculateIlluminance(m_r, m_g, m_b);  // not really precise
     }
 
     return static_cast<int>(m_ambientLight);
 }
 
-const QLoggingCategory &Apds9960LightSensor::logCategory() const { return CLASS_LC(); }
+const QLoggingCategory &Apds9960LightSensor::logCategory() const {
+    return lcApds9960Light();
+}
 
 uint16_t Apds9960LightSensor::calculateIlluminance(uint16_t r, uint16_t g, uint16_t b) {
     float lux;

--- a/sources/hardware/linux/arm/apds9960proximity.cpp
+++ b/sources/hardware/linux/arm/apds9960proximity.cpp
@@ -23,16 +23,13 @@
 
 #include "apds9960proximity.h"
 
-#include <QLoggingCategory>
 #include <QtDebug>
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "hw.dev.APDS9960.proximity");
 
 Apds9960ProximitySensor::Apds9960ProximitySensor(APDS9960 *apds, InterruptHandler *interruptHandler, QObject *parent)
     : ProximitySensor("APDS990 proximity sensor", parent), p_apds(apds) {
     Q_ASSERT(apds);
     Q_ASSERT(interruptHandler);
-    qCDebug(CLASS_LC) << name();
+    qCDebug(lcApds9960Prox) << name();
 
     connect(interruptHandler, &InterruptHandler::interruptEvent, this, [&](int event) {
         if (event == InterruptHandler::APDS9960) {
@@ -44,7 +41,7 @@ Apds9960ProximitySensor::Apds9960ProximitySensor(APDS9960 *apds, InterruptHandle
 void Apds9960ProximitySensor::proximityDetection(bool state) {
     if (p_apds->isOpen()) {
         if (state != m_proximityDetection) {
-            qCDebug(CLASS_LC) << "Proximity detection set to" << state;
+            qCDebug(lcApds9960Prox) << "Proximity detection set to" << state;
             if (state) {
                 // turn on
                 p_apds->enableProximityInterrupt();
@@ -64,13 +61,13 @@ void Apds9960ProximitySensor::readInterrupt() {
         m_proximity = p_apds->readProximity();
         if (m_proximity > 0) {
             // prevent log flooding while docking
-            qCDebug(CLASS_LC) << "Proximity" << m_proximity;
+            qCDebug(lcApds9960Prox) << "Proximity" << m_proximity;
         }
 
         if (m_proximityDetection) {
             if (m_proximity > m_proximitySetting) {
                 // turn of proximity detection
-                qCDebug(CLASS_LC) << "Proximity detected, turning detection off";
+                qCDebug(lcApds9960Prox) << "Proximity detected, turning detection off";
                 proximityDetection(false);
 
                 // let qml know
@@ -83,4 +80,6 @@ void Apds9960ProximitySensor::readInterrupt() {
     }
 }
 
-const QLoggingCategory &Apds9960ProximitySensor::logCategory() const { return CLASS_LC(); }
+const QLoggingCategory &Apds9960ProximitySensor::logCategory() const {
+    return lcApds9960Prox();
+}

--- a/sources/hardware/linux/arm/batterycharger_yio.cpp
+++ b/sources/hardware/linux/arm/batterycharger_yio.cpp
@@ -25,27 +25,26 @@
 
 #include <wiringPi.h>
 
-#include <QLoggingCategory>
-#include <QtDebug>
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "hw.dev.battery");
+#include "../../../logging.h"
 
 BatteryChargerYio::BatteryChargerYio(int pin, QObject *parent)
     : BatteryCharger("YIO battery charger", parent), m_pin(pin) {
     Q_ASSERT(pin);
-    qCDebug(CLASS_LC()) << name() << "on GPIO" << pin;
+    qCDebug(lcDevBatCharger) << name() << "on GPIO" << pin;
 }
 
 void BatteryChargerYio::batteryChargingOn() {
     pinMode(m_pin, OUTPUT);
     digitalWrite(m_pin, LOW);
-    qCDebug(CLASS_LC) << "Turning battery charging on";
+    qCDebug(lcDevBatCharger) << "Turning battery charging on";
 }
 
 void BatteryChargerYio::batteryChargingOff() {
     pinMode(m_pin, OUTPUT);
     digitalWrite(m_pin, HIGH);
-    qCDebug(CLASS_LC) << "Turning battery charging off";
+    qCDebug(lcDevBatCharger) << "Turning battery charging off";
 }
 
-const QLoggingCategory &BatteryChargerYio::logCategory() const { return CLASS_LC(); }
+const QLoggingCategory &BatteryChargerYio::logCategory() const {
+    return lcDevBatCharger();
+}

--- a/sources/hardware/linux/arm/bq27441.h
+++ b/sources/hardware/linux/arm/bq27441.h
@@ -117,7 +117,7 @@ class BQ27441 : public BatteryFuelGauge {
     // Extended Data Commands
     uint16_t getOpConfig();
 
- public slots:
+ public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
     void  updateBatteryValues() override;
 
     // Device interface

--- a/sources/hardware/linux/arm/drv2605.cpp
+++ b/sources/hardware/linux/arm/drv2605.cpp
@@ -37,29 +37,28 @@
 
 #include <unistd.h>
 
-#include <QLoggingCategory>
-#include <QtDebug>
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "hw.dev.DRV2605");
+#include "../../../logging.h"
 
 Drv2605::Drv2605(const QString& i2cDevice, int i2cDeviceId, QObject* parent)
     : HapticMotor("DRV2605 haptic motor", parent), m_i2cDevice(i2cDevice), m_i2cDeviceId(i2cDeviceId), m_i2cFd(0) {
     Q_ASSERT(!i2cDevice.isEmpty());
     Q_ASSERT(i2cDeviceId);
-    qCDebug(CLASS_LC()) << name() << i2cDevice << "with id:" << i2cDeviceId;
+    qCDebug(lcDevHaptic) << name() << i2cDevice << "with id:" << i2cDeviceId;
 }
 
-Drv2605::~Drv2605() { close(); }
+Drv2605::~Drv2605() {
+    close();
+}
 
 bool Drv2605::open() {
     if (isOpen()) {
-        qCWarning(CLASS_LC) << DBG_WARN_DEVICE_OPEN;
+        qCWarning(lcDevHaptic) << DBG_WARN_DEVICE_OPEN;
         return true;
     }
 
     m_i2cFd = wiringPiI2CSetupInterface(qPrintable(m_i2cDevice), m_i2cDeviceId);
     if (m_i2cFd == -1) {
-        qCCritical(CLASS_LC) << "Unable to open or select I2C device" << m_i2cDeviceId << "on" << m_i2cDevice;
+        qCCritical(lcDevHaptic) << "Unable to open or select I2C device" << m_i2cDeviceId << "on" << m_i2cDevice;
         setErrorString(ERR_DEV_HAPMOT_INIT);
         emit error(DeviceError::InitializationError, ERR_DEV_HAPMOT_INIT);
         return false;
@@ -122,17 +121,29 @@ void Drv2605::playEffect(Effect effect) {
     }
 }
 
-void Drv2605::setWaveform(uint8_t slot, uint8_t w) { writeRegister8(DRV2605_REG_WAVESEQ1 + slot, w); }
+void Drv2605::setWaveform(uint8_t slot, uint8_t w) {
+    writeRegister8(DRV2605_REG_WAVESEQ1 + slot, w);
+}
 
-void Drv2605::selectLibrary(uint8_t lib) { writeRegister8(DRV2605_REG_LIBRARY, lib); }
+void Drv2605::selectLibrary(uint8_t lib) {
+    writeRegister8(DRV2605_REG_LIBRARY, lib);
+}
 
-void Drv2605::go() { writeRegister8(DRV2605_REG_GO, 1); }
+void Drv2605::go() {
+    writeRegister8(DRV2605_REG_GO, 1);
+}
 
-void Drv2605::stop() { writeRegister8(DRV2605_REG_GO, 0); }
+void Drv2605::stop() {
+    writeRegister8(DRV2605_REG_GO, 0);
+}
 
-void Drv2605::setMode(uint8_t mode) { writeRegister8(DRV2605_REG_MODE, mode); }
+void Drv2605::setMode(uint8_t mode) {
+    writeRegister8(DRV2605_REG_MODE, mode);
+}
 
-void Drv2605::setRealtimeValue(uint8_t rtp) { writeRegister8(DRV2605_REG_RTPIN, rtp); }
+void Drv2605::setRealtimeValue(uint8_t rtp) {
+    writeRegister8(DRV2605_REG_RTPIN, rtp);
+}
 
 int Drv2605::readRegister8(uint8_t reg) {
     if (!isOpen()) {
@@ -148,4 +159,6 @@ void Drv2605::writeRegister8(uint8_t reg, uint8_t val) {
     wiringPiI2CWriteReg8(m_i2cFd, reg, val);
 }
 
-const QLoggingCategory& Drv2605::logCategory() const { return CLASS_LC(); }
+const QLoggingCategory& Drv2605::logCategory() const {
+    return lcDevHaptic();
+}

--- a/sources/hardware/linux/arm/hw_factory_yio.cpp
+++ b/sources/hardware/linux/arm/hw_factory_yio.cpp
@@ -26,7 +26,6 @@
 #include <wiringPi.h>
 
 #include <QDateTime>
-#include <QLoggingCategory>
 #include <QtDebug>
 
 #include "../../../configutil.h"
@@ -43,8 +42,6 @@
 
 const QString HardwareFactoryYio::DEF_I2C_DEVICE = "/dev/i2c-3";
 const int HardwareFactoryYio::DEF_BATTERY_CAPACITY = 2500;
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "hw.factory.yio");
 
 HardwareFactoryYio::HardwareFactoryYio(const QVariantMap &config, const QString &profile, QObject *parent)
     : HardwareFactoryLinux(config, profile, parent) {
@@ -119,11 +116,11 @@ bool HardwareFactoryYio::initializeWiringPi(const QVariantMap &config) {
     // The 2nd IO expander for display SPI and battery charger is accessed through WiringPi
     auto pinBase = ConfigUtil::getValue(config, "ioExpander/pinBase", 100).toInt();
     auto id = ConfigUtil::getValue(config, "ioExpander/i2cId", MCP23017_ADDRESS2).toInt();
-    qCDebug(CLASS_LC) << "Initializing 2nd MCP23017ML IO expander using WiringPi on i2c address" << id
+    qCDebug(lcHwFactory) << "Initializing 2nd MCP23017ML IO expander using WiringPi on i2c address" << id
                       << "with pin base" << pinBase;
 
     if (mcp23017Setup(pinBase, id) == 0) {
-        qCCritical(CLASS_LC) << "Error initializing 2nd MCP23017ML IO expander! i2c id:" << id
+        qCCritical(lcHwFactory) << "Error initializing 2nd MCP23017ML IO expander! i2c id:" << id
                              << "pin base:" << pinBase;
         return false;
     }
@@ -158,7 +155,7 @@ int HardwareFactoryYio::initialize() {
             while (!p_apds9960->colorDataReady()) {
                 delay(5);
                 if (QDateTime::currentMSecsSinceEpoch() > timeout) {
-                    qCWarning(CLASS_LC) << "Error retrieving color data from APDS9960 sensor";
+                    qCWarning(lcHwFactory) << "Error retrieving color data from APDS9960 sensor";
                     break;
                 }
             }

--- a/sources/hardware/linux/arm/mcp23017_handler.h
+++ b/sources/hardware/linux/arm/mcp23017_handler.h
@@ -29,9 +29,7 @@
 #include <wiringPi.h>
 #include <wiringPiI2C.h>
 
-#include <QLoggingCategory>
 #include <QString>
-#include <QtDebug>
 
 #include "../../interrupthandler.h"
 
@@ -65,8 +63,6 @@
 
 #define MCP23017_INT_ERR 255
 
-static Q_LOGGING_CATEGORY(CLASS_LC2, "hw.dev.MCP23017");
-
 class MCP23017 {
  public:
     MCP23017() : m_i2cFd(0) {}
@@ -84,7 +80,7 @@ class MCP23017 {
 
         m_i2cFd = wiringPiI2CSetupInterface(qPrintable(i2cDevice), i2cDeviceId);
         if (m_i2cFd == -1) {
-            qCCritical(CLASS_LC2) << "Unable to open or select I2C device" << i2cDevice << "on" << i2cDeviceId;
+            qCCritical(lcDevPortExp) << "Unable to open or select I2C device" << i2cDevice << "on" << i2cDeviceId;
             return false;
         }
 
@@ -132,7 +128,7 @@ class MCP23017 {
         bool volUp = !(gpioB & 0x040);
         bool topLeft = !(gpioB & 0x080);
         bool dpadDown = !(gpioB & 0x04);
-        qCDebug(CLASS_LC2) << "Reading reset keys [vol up][top left][dpad down]:" << volUp << topLeft << dpadDown;
+        qCDebug(lcDevPortExp) << "Reading reset keys [vol up][top left][dpad down]:" << volUp << topLeft << dpadDown;
         return volUp && topLeft && dpadDown;
     }
 

--- a/sources/hardware/linux/hw_factory_linux.cpp
+++ b/sources/hardware/linux/hw_factory_linux.cpp
@@ -22,9 +22,6 @@
 
 #include "hw_factory_linux.h"
 
-#include <QLoggingCategory>
-#include <QtDebug>
-
 #include "../../configutil.h"
 #include "../hw_config.h"
 #include "../systemservice_name.h"
@@ -36,8 +33,6 @@
 #if defined(CONFIG_WPA_SUPPLICANT)
 #include "wifi_wpasupplicant.h"
 #endif
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "hw.factory.linux");
 
 HardwareFactoryLinux::HardwareFactoryLinux(const QVariantMap &config, const QString &profile, QObject *parent)
     : HardwareFactoryDefault(parent) {
@@ -127,7 +122,7 @@ WifiControl *HardwareFactoryLinux::buildWifiControl(const QVariantMap &wifiCfg) 
 #if defined(CONFIG_WPA_SUPPLICANT)
     wpaSupplicantAvailable = true;
     if (!useShellScript) {
-        qCDebug(CLASS_LC()) << "Using wpa_supplicant as WiFi control interface";
+        qCDebug(lcHwFactory) << "Using wpa_supplicant as WiFi control interface";
         WifiWpaSupplicant *wps = new WifiWpaSupplicant(getWebServerControl(), getSystemService(), this);
 
         QVariantMap wpaCfg = wifiCfg.value(HW_CFG_WIFI_INTERFACE).toMap().value(HW_CFG_WIFI_IF_WPA_SUPP).toMap();
@@ -138,7 +133,7 @@ WifiControl *HardwareFactoryLinux::buildWifiControl(const QVariantMap &wifiCfg) 
     }
 #endif
     if (useShellScript || !wpaSupplicantAvailable) {
-        qCDebug(CLASS_LC()) << "Using shell scripts to control WiFi";
+        qCDebug(lcHwFactory) << "Using shell scripts to control WiFi";
         WifiShellScripts *wss = new WifiShellScripts(getSystemService(), this);
 
         QVariantMap shCfg = wifiCfg.value(HW_CFG_WIFI_INTERFACE).toMap().value(HW_CFG_WIFI_IF_SHELLSCRIPT).toMap();

--- a/sources/hardware/linux/systemd.cpp
+++ b/sources/hardware/linux/systemd.cpp
@@ -20,26 +20,27 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  *****************************************************************************/
 
-#include <QLoggingCategory>
-#include <QProcess>
-#include <QtDebug>
-
-#include "../hw_config.h"
 #include "systemd.h"
 
-static Q_LOGGING_CATEGORY(CLASS_LC, "systemd");
+#include <QProcess>
+
+#include "../../logging.h"
+#include "../hw_config.h"
 
 // TODO(mze) direct d-bus interaction? https://doc.qt.io/qt-5/qtdbus-index.html
 Systemd::Systemd(const QMap<SystemServiceName::Enum, QString> &serviceNameMap, QObject *parent)
     : SystemService(parent),
       m_useSudo(HW_DEF_SYSTEMD_SUDO),
       m_systemctlTimeout(HW_DEF_SYSTEMD_TIMEOUT),
-      m_serviceNameMap(serviceNameMap) {
+      m_serviceNameMap(serviceNameMap) {}
+
+void Systemd::setUseSudo(bool sudo) {
+    m_useSudo = sudo;
 }
 
-void Systemd::setUseSudo(bool sudo) { m_useSudo = sudo; }
-
-bool Systemd::isUseSudo() { return m_useSudo; }
+bool Systemd::isUseSudo() {
+    return m_useSudo;
+}
 
 bool Systemd::startService(SystemServiceName::Enum serviceName) {
     QString cmd = "systemctl start %1";
@@ -62,7 +63,7 @@ bool Systemd::reloadService(SystemServiceName::Enum serviceName) {
 }
 
 bool Systemd::launch(const QString &command) {
-    qCDebug(CLASS_LC) << command;
+    qCDebug(lcSystemd) << command;
 
     QProcess process;
 
@@ -76,12 +77,16 @@ bool Systemd::launch(const QString &command) {
         return true;
     }
 
-    qCWarning(CLASS_LC) << "Failed to execute" << command << ":"
-                        << "stdout:" << QString::fromLocal8Bit(process.readAllStandardOutput())
-                        << "errout:" << QString::fromLocal8Bit(process.readAllStandardError());
+    qCWarning(lcSystemd) << "Failed to execute" << command << ":"
+                         << "stdout:" << QString::fromLocal8Bit(process.readAllStandardOutput())
+                         << "errout:" << QString::fromLocal8Bit(process.readAllStandardError());
     return false;
 }
 
-int Systemd::systemctlTimeout() const { return m_systemctlTimeout; }
+int Systemd::systemctlTimeout() const {
+    return m_systemctlTimeout;
+}
 
-void Systemd::setSystemctlTimeout(int systemctlTimeout) { m_systemctlTimeout = systemctlTimeout; }
+void Systemd::setSystemctlTimeout(int systemctlTimeout) {
+    m_systemctlTimeout = systemctlTimeout;
+}

--- a/sources/hardware/linux/webserver_lighttpd.cpp
+++ b/sources/hardware/linux/webserver_lighttpd.cpp
@@ -20,13 +20,11 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  *****************************************************************************/
 
-#include <QFile>
-#include <QLoggingCategory>
-#include <QtDebug>
-
 #include "webserver_lighttpd.h"
 
-static Q_LOGGING_CATEGORY(CLASS_LC, "WebLighttpd");
+#include <QFile>
+
+#include "../../logging.h"
 
 WebServerLighttpd::WebServerLighttpd(SystemService *systemService, QObject *parent)
     : WebServerControl(parent),
@@ -34,25 +32,34 @@ WebServerLighttpd::WebServerLighttpd(SystemService *systemService, QObject *pare
       m_configFile(),
       m_wifiSetupConfig(),
       m_webConfiguratorConfig() {
+    qCDebug(lcServiceWeb) << "Created lighttpd service control";
 }
 
-bool WebServerLighttpd::startService() { return p_systemService->startService(SystemServiceName::WEBSERVER); }
+bool WebServerLighttpd::startService() {
+    return p_systemService->startService(SystemServiceName::WEBSERVER);
+}
 
-bool WebServerLighttpd::stopService() { return p_systemService->stopService(SystemServiceName::WEBSERVER); }
+bool WebServerLighttpd::stopService() {
+    return p_systemService->stopService(SystemServiceName::WEBSERVER);
+}
 
-bool WebServerLighttpd::restartService() { return p_systemService->restartService(SystemServiceName::WEBSERVER); }
+bool WebServerLighttpd::restartService() {
+    return p_systemService->restartService(SystemServiceName::WEBSERVER);
+}
 
-bool WebServerLighttpd::reloadService() { return p_systemService->reloadService(SystemServiceName::WEBSERVER); }
+bool WebServerLighttpd::reloadService() {
+    return p_systemService->reloadService(SystemServiceName::WEBSERVER);
+}
 
 bool WebServerLighttpd::startWifiSetupPortal() {
     if (!QFile::exists(m_wifiSetupConfig)) {
-        qCCritical(CLASS_LC) << "Lighttpd wifi-setup configuration file does not exist:" << m_wifiSetupConfig;
+        qCCritical(lcServiceWeb) << "Lighttpd wifi-setup configuration file does not exist:" << m_wifiSetupConfig;
         return false;
     }
     QFile::remove(m_configFile);
     if (!QFile::copy(m_wifiSetupConfig, m_configFile)) {
-        qCCritical(CLASS_LC) << "Error replacing lighttpd configuration file " << m_configFile
-                             << "with:" << m_wifiSetupConfig;
+        qCCritical(lcServiceWeb) << "Error replacing lighttpd configuration file " << m_configFile
+                                 << "with:" << m_wifiSetupConfig;
         return false;
     }
     return restartService();
@@ -60,28 +67,38 @@ bool WebServerLighttpd::startWifiSetupPortal() {
 
 bool WebServerLighttpd::startWebConfigurator() {
     if (!QFile::exists(m_webConfiguratorConfig)) {
-        qCCritical(CLASS_LC) << "Lighttpd web-configurator configuration file does not exist:"
-                             << m_webConfiguratorConfig;
+        qCCritical(lcServiceWeb) << "Lighttpd web-configurator configuration file does not exist:"
+                                 << m_webConfiguratorConfig;
         return false;
     }
     QFile::remove(m_configFile);
     if (!QFile::copy(m_webConfiguratorConfig, m_configFile)) {  // NOLINT false positive
-        qCCritical(CLASS_LC) << "Error replacing lighttpd configuration file " << m_configFile
-                             << "with:" << m_webConfiguratorConfig;
+        qCCritical(lcServiceWeb) << "Error replacing lighttpd configuration file " << m_configFile
+                                 << "with:" << m_webConfiguratorConfig;
         return false;
     }
     return restartService();
 }
 
-QString WebServerLighttpd::configFile() const { return m_configFile; }
+QString WebServerLighttpd::configFile() const {
+    return m_configFile;
+}
 
-void WebServerLighttpd::setConfigFile(const QString &configFile) { m_configFile = configFile; }
+void WebServerLighttpd::setConfigFile(const QString &configFile) {
+    m_configFile = configFile;
+}
 
-QString WebServerLighttpd::wifiSetupConfig() const { return m_wifiSetupConfig; }
+QString WebServerLighttpd::wifiSetupConfig() const {
+    return m_wifiSetupConfig;
+}
 
-void WebServerLighttpd::setWifiSetupConfig(const QString &wifiSetupConfig) { m_wifiSetupConfig = wifiSetupConfig; }
+void WebServerLighttpd::setWifiSetupConfig(const QString &wifiSetupConfig) {
+    m_wifiSetupConfig = wifiSetupConfig;
+}
 
-QString WebServerLighttpd::webConfiguratorConfig() const { return m_webConfiguratorConfig; }
+QString WebServerLighttpd::webConfiguratorConfig() const {
+    return m_webConfiguratorConfig;
+}
 
 void WebServerLighttpd::setWebConfiguratorConfig(const QString &webConfiguratorConfig) {
     m_webConfiguratorConfig = webConfiguratorConfig;

--- a/sources/hardware/linux/wifi_wpasupplicant.cpp
+++ b/sources/hardware/linux/wifi_wpasupplicant.cpp
@@ -35,7 +35,6 @@
 
 #include <QEventLoop>
 #include <QFile>
-#include <QLoggingCategory>
 #include <QProcess>
 #include <QThread>
 #include <QTimer>
@@ -44,11 +43,10 @@
 #include <cstdio>
 #include <exception>
 
+#include "../../logging.h"
 #include "../hw_config.h"
 #include "../systemservice_name.h"
 #include "common/wpa_ctrl.h"
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "WpaCtrl");
 
 const size_t WPA_BUF_SIZE = 2048;
 
@@ -99,7 +97,7 @@ QDebug operator<<(QDebug debug, const WifiStatus& wifiStatus) {
 
 bool WifiWpaSupplicant::init() {
     if (!m_ctrl) {
-        qCDebug(CLASS_LC) << "Initializing driver with socket:" << m_wpaSupplicantSocketPath;
+        qCDebug(lcWifiWpaCtrl) << "Initializing driver with socket:" << m_wpaSupplicantSocketPath;
 
         if (!connectWpaControlSocket()) {
             return false;
@@ -114,8 +112,8 @@ bool WifiWpaSupplicant::init() {
         startSignalStrengthScanning();
         startWifiStatusScanning();
 
-        qCDebug(CLASS_LC) << "wpa_supplicant control interface successfully initialized. WiFi connection:"
-                          << isConnected();
+        qCDebug(lcWifiWpaCtrl) << "wpa_supplicant control interface successfully initialized. WiFi connection:"
+                               << isConnected();
     }
 
     return true;
@@ -152,7 +150,7 @@ bool WifiWpaSupplicant::reset() {
 }
 
 bool WifiWpaSupplicant::clearConfiguredNetworks() {
-    qCDebug(CLASS_LC) << "Disconnecting and removing all networks...";
+    qCDebug(lcWifiWpaCtrl) << "Disconnecting and removing all networks...";
 
     if (!controlRequest("DISCONNECT")) {
         return false;
@@ -170,13 +168,13 @@ bool WifiWpaSupplicant::clearConfiguredNetworks() {
 
     stopScanTimer();
 
-    qCDebug(CLASS_LC) << "All networks removed and disconnected";
+    qCInfo(lcWifiWpaCtrl) << "All networks removed and disconnected";
 
     return true;
 }
 
 bool WifiWpaSupplicant::join(const QString& ssid, const QString& password, WifiSecurity::Enum security) {
-    qCDebug(CLASS_LC) << "Joining network:" << ssid << security;
+    qCInfo(lcWifiWpaCtrl) << "Joining network:" << ssid << security;
 
     // For more details about network creation & security option see:
     // https://github.com/loh-tar/wpa-cute/blob/master/src/networkconfig.cpp#L198
@@ -212,7 +210,7 @@ bool WifiWpaSupplicant::join(const QString& ssid, const QString& password, WifiS
             keyMgmnt = "WPA-PSK";
             break;
         default:
-            qCWarning(CLASS_LC) << "Authentication mode not (yet) implemented:" << security;
+            qCWarning(lcWifiWpaCtrl) << "Authentication mode not (yet) implemented:" << security;
             return false;
     }
 
@@ -309,8 +307,8 @@ bool WifiWpaSupplicant::setNetworkParam(const QString& networkId, const QString&
 void WifiWpaSupplicant::checkNetworkJoin() {
     m_checkNetworkCount++;
 
-    qCDebug(CLASS_LC) << "Checking Wifi state after enabling network configuration (" << m_checkNetworkCount << "/"
-                      << getNetworkJoinRetryCount() << ")";
+    qCInfo(lcWifiWpaCtrl) << "Checking Wifi state after enabling network configuration (" << m_checkNetworkCount << "/"
+                           << getNetworkJoinRetryCount() << ")";
 
     if (checkConnection()) {
         p_networkJoinTimer->stop();
@@ -325,7 +323,8 @@ void WifiWpaSupplicant::checkNetworkJoin() {
     if (m_checkNetworkCount >= getNetworkJoinRetryCount()) {
         p_networkJoinTimer->stop();
 
-        qCWarning(CLASS_LC) << "Failed to establish connection to AP after" << getNetworkJoinRetryCount() << "retries";
+        qCWarning(lcWifiWpaCtrl) << "Failed to establish connection to AP after" << getNetworkJoinRetryCount()
+                                 << "retries";
 
         emit joinError(JoinError::Timeout);
     }
@@ -343,7 +342,9 @@ bool WifiWpaSupplicant::writeWepKey(const QString& networkId, const QString& val
     return setNetworkParam(networkId, var.arg(keyId), value, !hex);
 }
 
-void WifiWpaSupplicant::startNetworkScan() { controlRequest("SCAN"); }
+void WifiWpaSupplicant::startNetworkScan() {
+    controlRequest("SCAN");
+}
 
 QList<WifiNetwork>& WifiWpaSupplicant::scanForAvailableNetworks(int timeout) {
     QEventLoop loop;
@@ -358,7 +359,7 @@ QList<WifiNetwork>& WifiWpaSupplicant::scanForAvailableNetworks(int timeout) {
 }
 
 bool WifiWpaSupplicant::startAccessPoint() {
-    qCDebug(CLASS_LC) << "TODO starting access point...";
+    qCDebug(lcWifiWpaCtrl) << "TODO starting access point...";
 
     if (!clearConfiguredNetworks()) {
         return false;
@@ -389,7 +390,7 @@ bool WifiWpaSupplicant::startAccessPoint() {
     // FIXME legacy function for PHP setup portal
     QFile qFile("/networklist");
     if (!qFile.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
-        qCWarning(CLASS_LC) << "Error opening file:" << qFile.fileName();
+        qCWarning(lcWifiWpaCtrl) << "Error opening file:" << qFile.fileName();
         return false;
     }
     QTextStream out(&qFile);
@@ -435,12 +436,12 @@ QString WifiWpaSupplicant::countryCode() {
 void WifiWpaSupplicant::setCountryCode(const QString& countryCode) {
     // turned out, that setting the country code in wpa_supplicant alone wasn't enough
     QProcess process;
-    QString command = "iw reg set " + countryCode;
+    QString  command = "iw reg set " + countryCode;
     process.start(command);
     if (!process.waitForFinished(10000)) {
-        qCWarning(CLASS_LC) << "Failed to execute" << command << ":"
-                            << "stdout:" << QString::fromLocal8Bit(process.readAllStandardOutput())
-                            << "errout:" << QString::fromLocal8Bit(process.readAllStandardError());
+        qCWarning(lcWifiWpaCtrl) << "Failed to execute" << command << ":"
+                                 << "stdout:" << QString::fromLocal8Bit(process.readAllStandardOutput())
+                                 << "errout:" << QString::fromLocal8Bit(process.readAllStandardError());
     }
 
     QString cmd = "SET country %1";
@@ -459,13 +460,13 @@ bool WifiWpaSupplicant::wpsPushButtonConfigurationAuth(const WifiNetwork& networ
 bool WifiWpaSupplicant::connectWpaControlSocket() {
     m_ctrl = wpa_ctrl_open(m_wpaSupplicantSocketPath.toStdString().c_str());
     if (!m_ctrl) {
-        qCCritical(CLASS_LC) << "wpa_ctrl_open(" << m_wpaSupplicantSocketPath << ") failed. Error:" << errno
-                             << strerror(errno);
+        qCCritical(lcWifiWpaCtrl) << "wpa_ctrl_open(" << m_wpaSupplicantSocketPath << ") failed. Error:" << errno
+                                  << strerror(errno);
         return false;
     }
     auto res = wpa_ctrl_attach(m_ctrl);
     if (res < 0) {
-        qCCritical(CLASS_LC) << "notifier attach failed with error:" << res;
+        qCCritical(lcWifiWpaCtrl) << "notifier attach failed with error:" << res;
         wpa_ctrl_close(m_ctrl);
         m_ctrl = nullptr;
         return false;
@@ -481,7 +482,7 @@ bool WifiWpaSupplicant::controlRequest(const QString& cmd) {
 
 bool WifiWpaSupplicant::controlRequest(const QString& cmd, char* buf, size_t buflen) {
     if (!m_ctrl) {
-        qCDebug(CLASS_LC) << "Not initialized. Ignoring control request:" << cmd;
+        qCDebug(lcWifiWpaCtrl) << "Not initialized. Ignoring control request:" << cmd;
         return false;
     }
 
@@ -492,7 +493,8 @@ bool WifiWpaSupplicant::controlRequest(const QString& cmd, char* buf, size_t buf
 
     buf[buflen] = '\0';
     if (res < 0) {
-        qCCritical(CLASS_LC) << "wpa_ctrl_request failed for command" << cmd << "with error:" << res << strerror(errno);
+        qCCritical(lcWifiWpaCtrl) << "wpa_ctrl_request failed for command" << cmd << "with error:" << res
+                                  << strerror(errno);
         return false;
     }
 
@@ -501,7 +503,7 @@ bool WifiWpaSupplicant::controlRequest(const QString& cmd, char* buf, size_t buf
 
     // filter out responses which are too verbose. Unfortunately there's no qCTrace()
     if (!cmd.startsWith("BSS ")) {
-        qCDebug(CLASS_LC) << cmd << "response:" << response;
+        qCDebug(lcWifiWpaCtrl) << cmd << "response:" << response;
     }
 
     if (response.startsWith("FAIL\n")) {
@@ -542,7 +544,7 @@ void WifiWpaSupplicant::parseEvent(char* msg) {
     }
 
     QString event = QString::fromLocal8Bit(pos);
-    qCDebug(CLASS_LC) << "Event:" << event;
+    qCDebug(lcWifiWpaCtrl) << "Event:" << event;
 
     if (event.startsWith(WPA_CTRL_REQ)) {
         processCtrlReq(event);
@@ -604,7 +606,7 @@ void WifiWpaSupplicant::processCtrlReq(const QString& req) {
     bool ok;
     int  id = networkId.toInt(&ok);
     if (!ok) {
-        qCWarning(CLASS_LC()) << "Bad request data:" << req;
+        qCWarning(lcWifiWpaCtrl()) << "Bad request data:" << req;
         return;
     }
 
@@ -631,7 +633,7 @@ void WifiWpaSupplicant::readScanResults() {
         if (!addBSS(i)) break;
     }
 
-    qCDebug(CLASS_LC) << "Networks found:" << m_scanResults.size();
+    qCDebug(lcWifiWpaCtrl) << "Networks found:" << m_scanResults.size();
     emit networksFound(m_scanResults);
 }
 
@@ -676,9 +678,9 @@ bool WifiWpaSupplicant::addBSS(int networkId) {
     }
 
     WifiSecurity::Enum security = getSecurityFromFlags(flags, networkId);
-    WifiNetwork  network{id, ssid, bssid, level, security, flags.contains("[WPS")};
+    WifiNetwork        network{id, ssid, bssid, level, security, flags.contains("[WPS")};
 
-    // qCDebug(CLASS_LC) << "Network found:" << network; // too verbose
+    // qCDebug(lcWifiWpaCtrl) << "Network found:" << network; // too verbose
 
     m_scanResults.append(network);
 
@@ -782,7 +784,7 @@ int WifiWpaSupplicant::parseSignalStrength(const char* buffer) {
     } else if ((rssi = strstr(buffer, "RSSI=")) != nullptr) {
         rssiValue = atoi(&rssi[sizeof("RSSI")]);
     } else {
-        qCDebug(CLASS_LC) << "Failed to get RSSI value";
+        qCInfo(lcWifiWpaCtrl) << "Failed to get RSSI value";
     }
 
     return rssiValue;
@@ -801,9 +803,10 @@ bool WifiWpaSupplicant::checkConnection() {
 
 bool WifiWpaSupplicant::saveConfiguration(bool resetCfgIfFailed /* = true */) {
     if (!controlRequest("SAVE_CONFIG")) {
-        qCWarning(CLASS_LC) << "Error saving current wpa_supplicant configuration! Please verify that "
-                               "/etc/wpa_supplicant/wpa_supplicant-wlan0.conf has 'update_config=1' set. Otherwise the "
-                               "configration cannot be persisted!";
+        qCWarning(lcWifiWpaCtrl)
+            << "Error saving current wpa_supplicant configuration! Please verify that "
+               "/etc/wpa_supplicant/wpa_supplicant-wlan0.conf has 'update_config=1' set. Otherwise the "
+               "configration cannot be persisted!";
         if (resetCfgIfFailed) {
             controlRequest("RECONFIGURE");  // reload from cfg and hope for the best
         }
@@ -819,7 +822,7 @@ void WifiWpaSupplicant::timerEvent(QTimerEvent* event) {
         return;
     }
     if (!isConnected()) {
-        qCDebug(CLASS_LC) << "Ignoring scanning event: WiFi is not connected!";
+        qCDebug(lcWifiWpaCtrl) << "Ignoring scanning event: WiFi is not connected!";
         return;
     }
 
@@ -827,7 +830,7 @@ void WifiWpaSupplicant::timerEvent(QTimerEvent* event) {
     if (m_wifiStatusScanning) {
         if (controlRequest("STATUS", buf, WPA_BUF_SIZE)) {
             WifiStatus wifiStatus = parseStatus(buf);
-            qCDebug(CLASS_LC) << "wifiStatus:" << wifiStatus;
+            qCDebug(lcWifiWpaCtrl) << "wifiStatus:" << wifiStatus;
 
             emit wifiStatusChanged(wifiStatus);
 
@@ -850,13 +853,17 @@ void WifiWpaSupplicant::timerEvent(QTimerEvent* event) {
     }
 }
 
-bool WifiWpaSupplicant::getRemoveNetworksBeforeJoin() const { return m_removeNetworksBeforeJoin; }
+bool WifiWpaSupplicant::getRemoveNetworksBeforeJoin() const {
+    return m_removeNetworksBeforeJoin;
+}
 
 void WifiWpaSupplicant::setRemoveNetworksBeforeJoin(bool removeNetworksBeforeJoin) {
     m_removeNetworksBeforeJoin = removeNetworksBeforeJoin;
 }
 
-QString WifiWpaSupplicant::getWpaSupplicantSocketPath() const { return m_wpaSupplicantSocketPath; }
+QString WifiWpaSupplicant::getWpaSupplicantSocketPath() const {
+    return m_wpaSupplicantSocketPath;
+}
 
 void WifiWpaSupplicant::setWpaSupplicantSocketPath(const QString& wpaSupplicantSocketPath) {
     m_wpaSupplicantSocketPath = wpaSupplicantSocketPath;

--- a/sources/hardware/macos/sysinfo_mac.cpp
+++ b/sources/hardware/macos/sysinfo_mac.cpp
@@ -37,16 +37,14 @@
 #include <sys/sysctl.h>
 #include <time.h>
 
-#include <QLoggingCategory>
-#include <QtDebug>
-
+#include "../../logging.h"
 #include "smc.h"
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "sysinfo");
 
 SystemInfoMac::SystemInfoMac(QObject *parent) : SystemInfo(parent) {}
 
-void SystemInfoMac::init() { getCpuSample(&m_lastCpuSample); }
+void SystemInfoMac::init() {
+    getCpuSample(&m_lastCpuSample);
+}
 
 QString SystemInfoMac::uptime() {
     struct timeval boottime;
@@ -54,7 +52,7 @@ QString SystemInfoMac::uptime() {
     int            mib[2] = {CTL_KERN, KERN_BOOTTIME};
 
     if (sysctl(mib, 2, &boottime, &len, NULL, 0) < 0) {
-        qCCritical(CLASS_LC) << "Failed to read kernel boot time";
+        qCCritical(lcSysInfo) << "Failed to read kernel boot time";
         return "error";
     }
 
@@ -108,9 +106,9 @@ float SystemInfoMac::cpuLoadAverage() {
 
     auto totalTime = delta.totalSystemTime + delta.totalUserTime + delta.totalIdleTime;
     auto onePercent = totalTime / 100.0;
-    qCDebug(CLASS_LC) << "system:" << static_cast<double>(delta.totalSystemTime) / onePercent
-                      << "user:" << static_cast<double>(delta.totalUserTime) / onePercent
-                      << "idle:" << static_cast<double>(delta.totalIdleTime) / onePercent;
+    qCDebug(lcSysInfo) << "system:" << static_cast<double>(delta.totalSystemTime) / onePercent
+                       << "user:" << static_cast<double>(delta.totalUserTime) / onePercent
+                       << "idle:" << static_cast<double>(delta.totalIdleTime) / onePercent;
 
     auto percent = (delta.totalSystemTime + delta.totalUserTime) / onePercent;
     return qBound(0.0f, static_cast<float>(percent), 100.0f);
@@ -127,7 +125,7 @@ bool SystemInfoMac::getCpuSample(SystemInfoMac::CpuSample *sample) {
     kern_return_t kr = host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &processorCount,
                                            reinterpret_cast<processor_info_array_t *>(&cpuLoad), &processorMsgCount);
     if (kr != KERN_SUCCESS) {
-        qCCritical(CLASS_LC) << "Error getting host processor information" << mach_error_string(kr);
+        qCCritical(lcSysInfo) << "Error getting host processor information" << mach_error_string(kr);
         return false;
     }
 

--- a/sources/hardware/mock/systemservice_mock.cpp
+++ b/sources/hardware/mock/systemservice_mock.cpp
@@ -20,21 +20,20 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  *****************************************************************************/
 
-#include <QLoggingCategory>
-#include <QtDebug>
-
 #include "systemservice_mock.h"
 
-static Q_LOGGING_CATEGORY(CLASS_LC, "SysSrvMock");
+#include "../../logging.h"
 
-SystemServiceMock::SystemServiceMock(QObject *parent) : SystemService(parent) { qCDebug(CLASS_LC) << Q_FUNC_INFO; }
+SystemServiceMock::SystemServiceMock(QObject *parent) : SystemService(parent) {
+    qCDebug(lcServiceMock) << "Created system service mock";
+}
 
 bool SystemServiceMock::startService(SystemServiceName::Enum serviceName) {
-    qCDebug(CLASS_LC) << "start service:" << serviceName;
+    qCDebug(lcServiceMock) << "Mocking start service:" << serviceName;
     return true;
 }
 
 bool SystemServiceMock::stopService(SystemServiceName::Enum serviceName) {
-    qCDebug(CLASS_LC) << "stop service:" << serviceName;
+    qCDebug(lcServiceMock) << "Mocking stop service:" << serviceName;
     return true;
 }

--- a/sources/hardware/mock/webserver_mock.cpp
+++ b/sources/hardware/mock/webserver_mock.cpp
@@ -20,34 +20,31 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  *****************************************************************************/
 
-#include <QLoggingCategory>
-#include <QtDebug>
-
 #include "webserver_mock.h"
 
-static Q_LOGGING_CATEGORY(CLASS_LC, "WebMock");
+#include "../../logging.h"
 
 WebServerMock::WebServerMock(QObject *parent)
     : WebServerControl(parent) {
-    qCDebug(CLASS_LC) << Q_FUNC_INFO;
+    qCDebug(lcServiceMock) << "Created web server mock";
 }
 
 bool WebServerMock::startService() {
-    qCDebug(CLASS_LC) << "startService";
+    qCDebug(lcServiceMock) << "Mocking web server start";
     return true;
 }
 
 bool WebServerMock::stopService() {
-    qCDebug(CLASS_LC) << "stopService";
+    qCDebug(lcServiceMock) << "Mocking web server stop";
     return true;
 }
 
 bool WebServerMock::startWifiSetupPortal() {
-    qCDebug(CLASS_LC) << "startWifiSetupPortal";
+    qCDebug(lcServiceMock) << "Mocking startWifiSetupPortal";
     return true;
 }
 
 bool WebServerMock::startWebConfigurator() {
-    qCDebug(CLASS_LC) << "startWebConfiugorator";
+    qCDebug(lcServiceMock) << "Mocking startWebConfigurator";
     return true;
 }

--- a/sources/hardware/mock/wifi_mock.cpp
+++ b/sources/hardware/mock/wifi_mock.cpp
@@ -22,40 +22,43 @@
 
 #include "wifi_mock.h"
 
-#include <QLoggingCategory>
-#include <QtDebug>
+#include "../../logging.h"
 
-static Q_LOGGING_CATEGORY(CLASS_LC, "WifiMock");
-
-WifiMock::WifiMock(QObject *parent) : WifiControl(parent), m_countryCode("CH") { qCDebug(CLASS_LC) << Q_FUNC_INFO; }
+WifiMock::WifiMock(QObject *parent) : WifiControl(parent), m_countryCode("CH") {
+    qCDebug(lcWifiMock) << "Created wifi mock";;
+}
 
 WifiMock::~WifiMock() {}
 
 bool WifiMock::init() {
-    qCDebug(CLASS_LC) << "init";
+    qCDebug(lcWifiMock) << "Wifi mock init";
     startSignalStrengthScanning();
     startWifiStatusScanning();
     startNetworkScan();
     return true;
 }
 
-void WifiMock::on() { qCDebug(CLASS_LC) << "on"; }
+void WifiMock::on() {
+    qCDebug(lcWifiMock) << "Wifi mock on";
+}
 
-void WifiMock::off() { qCDebug(CLASS_LC) << "off"; }
+void WifiMock::off() {
+    qCDebug(lcWifiMock) << "Wifi mock off";
+}
 
 bool WifiMock::reset() {
-    qCDebug(CLASS_LC) << "reset";
+    qCDebug(lcWifiMock) << "Wifi mock reset";
     // just make sure all timers are running
     return init();
 }
 
 bool WifiMock::clearConfiguredNetworks() {
-    qCDebug(CLASS_LC) << "clearConfiguredNetworks";
+    qCDebug(lcWifiMock) << "Wifi mock clearConfiguredNetworks";
     return true;
 }
 
 bool WifiMock::join(const QString &ssid, const QString &password, WifiSecurity::Enum security) {
-    qCDebug(CLASS_LC) << "join " << ssid;
+    qCDebug(lcWifiMock) << "Wifi mock join " << ssid;
 
     if (!validateAuthentication(security, password)) {
         emit joinError(WifiControl::AuthFailure);
@@ -68,12 +71,12 @@ bool WifiMock::join(const QString &ssid, const QString &password, WifiSecurity::
 }
 
 bool WifiMock::isConnected() {
-    qCDebug(CLASS_LC) << "isConnected";
+    qCDebug(lcWifiMock) << "Wifi mock isConnected";
     return rand() % 2 == 0;
 }
 
 void WifiMock::startNetworkScan() {
-    qCDebug(CLASS_LC) << "startNetworkScan";
+    qCDebug(lcWifiMock) << "Wifi mock startNetworkScan";
     setScanStatus(Scanning);
 
     m_scanResults.clear();
@@ -87,13 +90,17 @@ void WifiMock::startNetworkScan() {
 }
 
 bool WifiMock::startAccessPoint() {
-    qCDebug(CLASS_LC) << "startAccessPoint";
+    qCDebug(lcWifiMock) << "Wifi mock startAccessPoint";
     return false;
 }
 
-QString WifiMock::countryCode() { return m_countryCode; }
+QString WifiMock::countryCode() {
+    return m_countryCode;
+}
 
-void WifiMock::setCountryCode(const QString &countryCode) { m_countryCode = countryCode; }
+void WifiMock::setCountryCode(const QString &countryCode) {
+    m_countryCode = countryCode;
+}
 
 WifiStatus WifiMock::wifiStatus() const {
     return WifiStatus{"WiFi Mock", "", "127.0.0.1", "de:ad:be:ef:00:00", -70 + qrand() % 9};

--- a/sources/hardware/touchdetect.cpp
+++ b/sources/hardware/touchdetect.cpp
@@ -22,10 +22,7 @@
 
 #include "touchdetect.h"
 
-#include <QLoggingCategory>
-#include <QtDebug>
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "hw.touchevent");
+#include "../logging.h"
 
 TouchEventFilter *TouchEventFilter::s_instance = nullptr;
 
@@ -33,7 +30,7 @@ TouchEventFilter::TouchEventFilter() {
     s_instance = this;
     m_source   = nullptr;
 
-    qCDebug(CLASS_LC) << "TouchEventFilter init";
+    qCDebug(lcTouch) << "TouchEventFilter init";
 }
 
 TouchEventFilter::~TouchEventFilter() {
@@ -44,7 +41,7 @@ TouchEventFilter::~TouchEventFilter() {
 void TouchEventFilter::setSource(QObject *source) {
     source->installEventFilter(this);
     m_source = source;
-    qCDebug(CLASS_LC) << "Setting source" << m_source;
+    qCDebug(lcTouch) << "Setting source" << m_source;
 }
 
 QObject *TouchEventFilter::getInstance(QQmlEngine *engine, QJSEngine *scriptEngine) {

--- a/sources/hardware/wifi_control.cpp
+++ b/sources/hardware/wifi_control.cpp
@@ -20,12 +20,10 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  *****************************************************************************/
 
-#include <QLoggingCategory>
-
-#include "hw_config.h"
 #include "wifi_control.h"
 
-static Q_LOGGING_CATEGORY(CLASS_LC, "WifiCtrl");
+#include "../logging.h"
+#include "hw_config.h"
 
 WifiControl::WifiControl(QObject* parent)
     : QObject(parent),
@@ -39,8 +37,7 @@ WifiControl::WifiControl(QObject* parent)
       m_pollInterval(HW_DEF_WIFI_POLL_INTERVAL),
       m_timerId(0),
       m_networkJoinRetryCount(HW_DEF_WIFI_JOIN_RETRY),
-      m_networkJoinRetryDelay(HW_DEF_WIFI_JOIN_DELAY) {
-}
+      m_networkJoinRetryDelay(HW_DEF_WIFI_JOIN_DELAY) {}
 
 WifiControl::~WifiControl() {
     stopScanTimer();
@@ -51,7 +48,7 @@ bool WifiControl::validateAuthentication(WifiSecurity::Enum security, const QStr
         case WifiSecurity::IEEE8021X:
         case WifiSecurity::WPA_EAP:
         case WifiSecurity::WPA2_EAP:
-            qWarning(CLASS_LC) << "Authentication mode not supported:" << security;
+            qCWarning(lcWifi) << "Authentication mode not supported:" << security;
             return false;
         default:
             break;
@@ -59,7 +56,7 @@ bool WifiControl::validateAuthentication(WifiSecurity::Enum security, const QStr
 
     if (security == WifiSecurity::DEFAULT || security == WifiSecurity::WPA_PSK || security == WifiSecurity::WPA2_PSK) {
         if (preSharedKey.length() < 8 || preSharedKey.length() > 64) {
-            qWarning(CLASS_LC) << "WPA Pre-Shared Key Error:"
+            qCCritical(lcWifi) << "WPA Pre-Shared Key Error:"
                                << "WPA-PSK requires a passphrase of 8 to 63 characters or 64 hex digit PSK";
             return false;
         }
@@ -71,14 +68,16 @@ bool WifiControl::validateAuthentication(WifiSecurity::Enum security, const QStr
 /**
  * Default implementation
  */
-bool WifiControl::isConnected() { return m_connected; }
+bool WifiControl::isConnected() {
+    return m_connected;
+}
 
 void WifiControl::setConnected(bool state) {
     if (state == m_connected) {
         return;
     }
 
-    qCDebug(CLASS_LC) << "Connection status changed to:" << state;
+    qCInfo(lcWifi) << "Connection status changed to:" << state;
     m_connected = state;
 
     if (state) {
@@ -88,7 +87,9 @@ void WifiControl::setConnected(bool state) {
     }
 }
 
-WifiStatus WifiControl::wifiStatus() const { return m_wifiStatus; }
+WifiStatus WifiControl::wifiStatus() const {
+    return m_wifiStatus;
+}
 
 WifiControl::ScanStatus WifiControl::scanStatus() const {
     return m_scanStatus;
@@ -99,7 +100,9 @@ void WifiControl::setScanStatus(ScanStatus stat) {
     scanStatusChanged(m_scanStatus);
 }
 
-QList<WifiNetwork>& WifiControl::scanResult() { return m_scanResults; }
+QList<WifiNetwork>& WifiControl::scanResult() {
+    return m_scanResults;
+}
 
 QVariantList WifiControl::networkScanResult() const {
     QVariantList list;
@@ -135,14 +138,14 @@ void WifiControl::stopWifiStatusScanning() {
 
 void WifiControl::startScanTimer() {
     if (m_timerId == 0) {
-        qCDebug(CLASS_LC) << "Starting scan timer with interval:" << m_pollInterval;
+        qCDebug(lcWifi) << "Starting scan timer with interval:" << m_pollInterval;
         m_timerId = startTimer(m_pollInterval);
     }
 }
 
 void WifiControl::stopScanTimer() {
     if (m_timerId > 0) {
-        qCDebug(CLASS_LC) << "Stopping scan timer";
+        qCDebug(lcWifi) << "Stopping scan timer";
         killTimer(m_timerId);
         m_timerId = 0;
     }

--- a/sources/hardware/wifi_control.h
+++ b/sources/hardware/wifi_control.h
@@ -22,7 +22,6 @@
 
 #pragma once
 
-#include <QDebug>
 #include <QList>
 #include <QObject>
 #include <QProcess>

--- a/sources/hardware/windows/sysinfo_win.cpp
+++ b/sources/hardware/windows/sysinfo_win.cpp
@@ -29,10 +29,7 @@
 
 #include <sysinfoapi.h>
 
-#include <QLoggingCategory>
-#include <QtDebug>
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "sysinfo");
+#include "../../logging.h"
 
 SystemInfoWin::SystemInfoWin(QObject* parent) : SystemInfo(parent) {}
 
@@ -90,7 +87,7 @@ bool SystemInfoWin::getCpuSample(SystemInfoWin::CpuSample* sample) {
     FILETIME kernelTime, userTime, idleTime;
 
     if (!GetSystemTimes(&idleTime, &kernelTime, &userTime)) {
-        qCCritical(CLASS_LC) << "Error getting system time information";
+        qCCritical(lcSysInfo) << "Error getting system time information";
         return false;
     }
 

--- a/sources/integrations/integrations.cpp
+++ b/sources/integrations/integrations.cpp
@@ -23,21 +23,18 @@
 #include "integrations.h"
 
 #include <QDirIterator>
-#include <QLoggingCategory>
 #include <QPluginLoader>
-#include <QtDebug>
 
 #include "../config.h"
 #include "../entities/entities.h"
 #include "../launcher.h"
+#include "../logging.h"
 #include "../notifications.h"
 #include "../yioapi.h"
 
 IntegrationsInterface::~IntegrationsInterface() {}
 
 Integrations* Integrations::s_instance = nullptr;
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "plugin");
 
 Integrations::Integrations(const QString& pluginPath) : m_pluginPath(pluginPath) {
     s_instance = this;
@@ -49,7 +46,7 @@ Integrations::Integrations(const QString& pluginPath) : m_pluginPath(pluginPath)
         QString       pluginName = pluginLoader.metaData()["MetaData"].toObject().value("name").toString();
         if (pluginName != "") {
             m_supportedIntegrations.append(pluginName.toLower());
-            qCDebug(CLASS_LC()) << "Adding supported integration type:" << pluginName;
+            qCDebug(lcPlugin) << "Adding supported integration type:" << pluginName;
         }
     }
 }
@@ -67,9 +64,13 @@ QObject* Integrations::loadPlugin(const QString& type) {
     return obj;
 }
 
-QObject* Integrations::getPlugin(const QString& type) { return m_plugins.value(type); }
+QObject* Integrations::getPlugin(const QString& type) {
+    return m_plugins.value(type);
+}
 
-QList<QObject*> Integrations::getAllPlugins() { return m_plugins.values(); }
+QList<QObject*> Integrations::getAllPlugins() {
+    return m_plugins.values();
+}
 
 bool Integrations::isPluginLoaded(const QString& type) {
     if (m_plugins.contains(type)) {
@@ -96,7 +97,7 @@ void Integrations::createInstance(QObject* pluginObj, QVariantMap map) {
 QJsonObject Integrations::getPluginMetaData(const QString& pluginName) {
     Launcher* launcher = new Launcher();
     QString   pluginPath = launcher->getPluginPath(m_pluginPath, pluginName);
-    qCDebug(CLASS_LC()) << "Getting metadata for:" << pluginPath;
+    qCDebug(lcPlugin) << "Getting metadata for:" << pluginPath;
     QPluginLoader pluginLoader(pluginPath);
     return pluginLoader.metaData()["MetaData"].toObject();
 }
@@ -109,7 +110,7 @@ void Integrations::load() {
     // read the config
     QVariantMap c = config->getAllIntegrations();
 
-    qCDebug(CLASS_LC) << "Plugin path:" << m_pluginPath;
+    qCDebug(lcPlugin) << "Plugin path:" << m_pluginPath;
 
     // let's load the plugins
     m_integrationsToLoad = c.count();
@@ -148,14 +149,16 @@ void Integrations::onCreateDone(QMap<QObject*, QVariant> map) {
     }
     m_integrationsLoaded++;
 
-    qCDebug(CLASS_LC) << "Integrations loaded:" << m_integrationsLoaded << "from:" << m_integrationsToLoad;
+    qCDebug(lcPlugin) << "Integrations loaded:" << m_integrationsLoaded << "of" << m_integrationsToLoad;
 
     if (m_integrationsLoaded == m_integrationsToLoad) {
         emit loadComplete();
     }
 }
 
-QList<QObject*> Integrations::list() { return m_integrations.values(); }
+QList<QObject*> Integrations::list() {
+    return m_integrations.values();
+}
 
 QStringList Integrations::listIds() {
     QStringList r_list;
@@ -168,10 +171,12 @@ QStringList Integrations::listIds() {
     return r_list;
 }
 
-QObject* Integrations::get(const QString& id) { return m_integrations.value(id); }
+QObject* Integrations::get(const QString& id) {
+    return m_integrations.value(id);
+}
 
 void Integrations::add(const QVariantMap& config, QObject* obj, const QString& type) {
-    qCDebug(CLASS_LC()) << "Adding integration:" << type;
+    qCDebug(lcPlugin) << "Adding integration:" << type;
     const QString id = config.value(Config::KEY_ID).toString();
     m_integrations.insert(id, obj);
     m_integrationsFriendlyNames.insert(id, config.value(Config::KEY_FRIENDLYNAME).toString());
@@ -185,14 +190,18 @@ void Integrations::remove(const QString& id) {
     emit listChanged();
 }
 
-QString Integrations::getFriendlyName(const QString& id) { return m_integrationsFriendlyNames.value(id); }
+QString Integrations::getFriendlyName(const QString& id) {
+    return m_integrationsFriendlyNames.value(id);
+}
 
 QString Integrations::getFriendlyName(QObject* obj) {
     QString name = m_integrations.key(obj);
     return m_integrationsFriendlyNames.value(name);
 }
 
-QString Integrations::getMDNS(const QString& id) { return m_integrationsMdns.value(id); }
+QString Integrations::getMDNS(const QString& id) {
+    return m_integrationsMdns.value(id);
+}
 
 QStringList Integrations::getMDNSList() {
     QStringList mdnsList;
@@ -203,7 +212,9 @@ QStringList Integrations::getMDNSList() {
     return mdnsList;
 }
 
-QString Integrations::getType(const QString& id) { return m_integrationsTypes.value(id); }
+QString Integrations::getType(const QString& id) {
+    return m_integrationsTypes.value(id);
+}
 
 QString Integrations::getTypeByMdns(const QString& mdns) {
     for (int i = 0; i < m_supportedIntegrations.length(); i++) {

--- a/sources/launcher.cpp
+++ b/sources/launcher.cpp
@@ -22,20 +22,17 @@
 
 #include "launcher.h"
 
-#include <QLoggingCategory>
 #include <QPluginLoader>
-#include <QtDebug>
 
+#include "logging.h"
 #include "notifications.h"
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "plugin");
 
 Launcher::Launcher(QObject *parent) : QObject(parent), m_process(new QProcess(this)) {}
 
 QString Launcher::launch(const QString &program) {
     m_process->start(program);
     m_process->waitForFinished(-1);
-    QByteArray bytes  = m_process->readAllStandardOutput();
+    QByteArray bytes = m_process->readAllStandardOutput();
     QString    output = QString::fromLocal8Bit(bytes);
     return output;
 }
@@ -45,11 +42,11 @@ QObject *Launcher::loadPlugin(const QString &path, const QString &pluginName) {
     QPluginLoader pluginLoader(pluginPath, this);
 
     QJsonObject metaData = pluginLoader.metaData()["MetaData"].toObject();
-    qCInfo(CLASS_LC) << "LOADING PLUGIN:" << pluginPath << "version:" << metaData["version"].toString();
+    qCInfo(lcPlugin) << "Loading plugin:" << pluginPath << "version:" << metaData["version"].toString();
 
     QObject *plugin = pluginLoader.instance();
     if (!plugin) {
-        qCCritical(CLASS_LC) << "FAILED TO LOAD PLUGIN: " << pluginPath << pluginLoader.errorString();
+        qCCritical(lcPlugin) << "Failed to load plugin:" << pluginPath << pluginLoader.errorString();
         Notifications::getInstance()->add(true, "Failed to load " + QString(pluginName));
     }
 

--- a/sources/logger.cpp
+++ b/sources/logger.cpp
@@ -1,5 +1,6 @@
 /******************************************************************************
  *
+ * Copyright (C) 2020 Markus Zehnder <business@markuszehnder.ch>
  * Copyright (C) 2019 Christian Riedl <ric@rts.co.at>
  *
  * This file is part of the YIO-Remote software project.
@@ -22,249 +23,341 @@
 
 #include "logger.h"
 
-#include <QDir>
+#include <QDateTime>
+#include <QDebug>
+#include <QLoggingCategory>
 #include <iostream>
 
-Logger*     Logger::s_instance        = nullptr;
-QStringList Logger::s_msgTypeString   = {"DEBUG", "WARN ", "CRIT ", "FATAL", "INFO "};  // parallel to QMsgType
-QtMsgType   Logger::s_msgTypeSorted[] = {QtDebugMsg, QtInfoMsg, QtWarningMsg, QtCriticalMsg,
-                                       QtFatalMsg};  // sorted by severity
+#include "logging.h"
 
-Logger::Logger(const QString& path, QString logLevel, bool console, bool showSource, int queueSize, int purgeHours,
-               QObject* parent)
+// Get the default Qt message handler.
+static const QtMessageHandler QT_DEFAULT_MESSAGE_HANDLER = qInstallMessageHandler(0);
+
+Logger* Logger::instance() {
+    static Logger log;
+    return &log;
+}
+
+Logger::Logger(QObject* parent)
     : QObject(parent),
-      m_consoleEnabled(console),
-      m_fileEnabled(path.length() > 0),
+      m_logLevel(QtDebugMsg),
+      m_defHandlerEnabled(true),
+      m_fileEnabled(false),
+      m_purgeFileHours(5 * 24),
+      m_lastRotationDay(0),
       m_queueEnabled(false),
-      m_showSource(showSource),
-      m_maxQueueSize(queueSize),
-      m_directory(path),
-      m_file(nullptr) {
-    s_instance = this;
+      m_showSource(true),
+      m_maxQueueSize(0) {
+    // set default message pattern if QT_MESSAGE_PATTERN is not set
+    qSetMessagePattern(QStringLiteral(
+        "%{time yyyy-MM-dd hh:mm:ss:zzz t} %{if-debug}DEBUG%{endif}%{if-info}INFO %{endif}%{if-warning}WARN "
+        "%{endif}%{if-critical}CRIT %{endif}%{if-fatal}FATAL%{endif} [%{category}]:\t%{message}\t[%{file}:%{line}]"));
 
-    Q_ASSERT(s_msgTypeString.length() == QtMsgType::QtInfoMsg + 1);
+    qInstallMessageHandler(&yioMessageHandler);
+}
 
-    if (m_fileEnabled && !QDir(m_directory).exists()) {
-        QDir().mkdir(m_directory);
+Logger::~Logger() {
+    qInstallMessageHandler(0);
+    close();
+}
+
+void Logger::close() {
+    QMutexLocker locker(&m_mutex);
+
+    if (m_logStream) {
+        m_logStream->flush();
+        m_logStream.reset(nullptr);
+        m_logFile.close();
     }
+}
 
-    qInstallMessageHandler(&messageOutput);
-    defineLogCategory("default", QtMsgType::QtInfoMsg, QLoggingCategory::defaultCategory());
-    if (!logLevel.isEmpty()) {
-        setLogLevel(static_cast<QtMsgType>(toMsgType(logLevel)));
+void Logger::yioMessageHandler(::QtMsgType type, const QMessageLogContext& context, const QString& msg) {
+    Logger::instance()->processMessage(type, context, msg);
+}
+
+void Logger::setLogLevel(const QString& logLevel) {
+    setLogLevel(toMsgType(logLevel));
+}
+
+void Logger::setLogLevel(QtMsgType logLevel) {
+    const QSet<QString> noDebugRules = {QStringLiteral("yio*.debug=false"), QStringLiteral("qml.debug=false")};
+    const QSet<QString> noInfoRules = {QStringLiteral("yio*.info=false"), QStringLiteral("qml.info=false")};
+    const QSet<QString> noWarningRules = {QStringLiteral("yio*.warning=false"), QStringLiteral("qml.warning=false")};
+    const QSet<QString> noCriticalRules = {QStringLiteral("yio*.critical=false"), QStringLiteral("qml.critical=false")};
+
+    m_logLevel = logLevel;
+
+    switch (logLevel) {
+        case QtInfoMsg:
+            removeLogRule(noInfoRules + noWarningRules + noCriticalRules);
+            addLogRule(noDebugRules);
+            break;
+        case QtWarningMsg:
+            removeLogRule(noWarningRules + noCriticalRules);
+            addLogRule(noDebugRules + noInfoRules);
+            break;
+        case QtCriticalMsg:
+            removeLogRule(noCriticalRules);
+            addLogRule(noDebugRules + noInfoRules + noWarningRules);
+            break;
+        case QtFatalMsg:
+            addLogRule(noDebugRules + noInfoRules + noWarningRules + noCriticalRules);
+            break;
+        default:
+            removeLogRule(noDebugRules + noInfoRules + noWarningRules + noCriticalRules);
+    }
+}
+
+QtMsgType Logger::toMsgType(const QString& logLevel) const {
+    QString level = logLevel.toUpper();
+
+    if (level == QLatin1String("DEBUG")) {
+        return QtMsgType::QtDebugMsg;
+    } else if (level == QLatin1String("INFO")) {
+        return QtMsgType::QtInfoMsg;
+    } else if (level == QLatin1String("WARN") || level == QLatin1String("WARNING")) {
+        return QtMsgType::QtWarningMsg;
+    } else if (level == QLatin1String("CRIT") || level == QLatin1String("CRITICAL")) {
+        return QtMsgType::QtCriticalMsg;
+    } else if (level == QLatin1String("FATAL")) {
+        return QtMsgType::QtFatalMsg;
+    } else {
+        return QtMsgType::QtInfoMsg;
+    }
+}
+
+void Logger::addLogRule(const QSet<QString>& rules) {
+    setLogRules(m_logRules + rules);
+}
+
+void Logger::removeLogRule(const QSet<QString>& rules) {
+    setLogRules(m_logRules - rules);
+}
+
+void Logger::clearLogRules() {
+    setLogRules({});
+}
+
+void Logger::setLogRules(const QSet<QString>& rules) {
+    // Get default rules as baseline and append our custom rules. Last one wins!
+    // Note: individual rules in QT_LOGGING_RULES can be separated by semicolon or newline
+    static const QString defaultRules =
+        qEnvironmentVariable("QT_LOGGING_RULES").replace(QLatin1Char(';'), QLatin1Char('\n'));
+
+    m_logRules = rules;
+    QLoggingCategory::setFilterRules(defaultRules + QLatin1Char('\n') + rules.values().join(QLatin1Char('\n')));
+}
+
+void Logger::processMessage(QtMsgType type, const QMessageLogContext& context, const QString& msg) {
+    if (m_defHandlerEnabled) {
+        // forward to default Qt message handler to output message to console or journald on YIO remote
+        (*QT_DEFAULT_MESSAGE_HANDLER)(type, context, msg);
     }
 
     if (m_fileEnabled) {
-        purgeFiles(purgeHours);
+        if (m_lastRotationDay != QDate::currentDate().day()) {
+            rotateLogFile();
+        }
+        writeFile(qFormatLogMessage(type, context, msg));
     }
-}
-Logger::~Logger() {
-    if (m_file != nullptr) {
-        m_file->close();
-    }
-    s_instance = nullptr;
-}
 
-int Logger::toMsgType(const QString& msgType) {
-    QString mt = msgType.toUpper();
-    for (int i = 0; i < s_msgTypeString.length(); i++) {
-        if (mt.startsWith(s_msgTypeString[i].trimmed())) {
-            return i;
-        }
-    }
-    return QtMsgType::QtDebugMsg;
-}
-
-void Logger::setLogLevel(int logLevel) {
-    QtMsgType level = static_cast<QtMsgType>(logLevel);
-    m_logLevel      = level;
-    m_logLevelMask  = logLevelToMask(level);
-}
-
-void Logger::setCategoryLogLevel(const QString& category, int logLevel) {
-    // set integrations loglevel
-    defineLogCategory(category, logLevel);
-}
-void Logger::defineLogCategory(const QString& category, int level, QLoggingCategory* loggingCategory,
-                               PluginInterface* plugin) {
-    QtMsgType  logLevel = static_cast<QtMsgType>(level);
-    SCategory* cat      = m_categories.value(category);
-    if (cat == nullptr) {
-        // Add new category
-        cat = new SCategory(logLevel, loggingCategory, plugin);
-        m_categories.insert(category, cat);
-        qInfo() << "Create logging category" << category << "Level : " << s_msgTypeString[level];
-    } else {
-        if (cat->logLevel != logLevel) {
-            qInfo() << "Set logging category" << category << "Level : " << s_msgTypeString[level];
-            cat->logLevel     = logLevel;
-            cat->logLevelMask = logLevelToMask(logLevel);
-        }
-    }
-    bool enable = false;
-    int  size   = sizeof(s_msgTypeSorted) / sizeof(s_msgTypeSorted[0]);
-    for (int i = 0; i < size; i++) {
-        QtMsgType thisLevel = s_msgTypeSorted[i];
-        if (logLevel == thisLevel) {
-            enable = true;
-        }
-        if (cat->logCategory != nullptr) {
-            cat->logCategory->setEnabled(thisLevel, enable);
-        }
-        if (cat->plugin != nullptr) {
-            cat->plugin->setLogEnabled(thisLevel, enable);
-        }
-    }
-}
-void Logger::removeCategory(const QString& category) {
-    if (m_categories.contains(category)) {
-        m_categories.remove(category);
-    }
-}
-
-int Logger::getCategoryLogLevel(const QString& category) {
-    SCategory* cat = m_categories.value(category);
-    return (cat == nullptr) ? m_logLevel : cat->logLevel;
-}
-
-quint16 Logger::logLevelToMask(QtMsgType logLevel) {
-    int     size   = sizeof(s_msgTypeSorted) / sizeof(s_msgTypeSorted[0]);
-    bool    enable = false;
-    quint16 mask   = 0;
-    for (int i = 0; i < size; i++) {
-        if (logLevel == s_msgTypeSorted[i]) {
-            enable = true;
-        }
-        if (enable) {
-            mask |= (1 << i);
-        }
-    }
-    return mask;
-}
-
-void Logger::processMessage(QtMsgType type, const char* category, const char* source, int line, const QString& msg,
-                            bool writeanyHow) {
-    QString    cat = category == nullptr ? "default" : category;
-    SCategory* c   = m_categories.value(cat);
-    if (c == nullptr) {
-        // Add new category
-        c = new SCategory(m_logLevel);  // Initialize with overall log level
-        m_categories.insert(cat, c);
-    }
-    Q_ASSERT(type <= QtMsgType::QtInfoMsg);
-    c->count[type]++;
-    // if overall or category specific is enabled
-    if (writeanyHow || !!((m_logLevelMask | c->logLevelMask) & (1 << type))) {
+    if (m_queueEnabled) {
         QString sourcePosition;
-        if (m_showSource && source != nullptr) {
-            sourcePosition = QString("%1:%2").arg(source).arg(line);
+        if (m_showSource && context.file != nullptr) {
+            sourcePosition = QString("%1:%2").arg(context.file).arg(context.line);
         }
         QDateTime dt = QDateTime::currentDateTimeUtc();
-        SMessage  message(type, dt.toTime_t(), cat, msg, sourcePosition);
-        if (m_consoleEnabled) {
-            writeConsole(message);
-        }
-        if (m_fileEnabled) {
-            writeFile(message, dt);
-        }
-        if (m_queueEnabled) {
-            writeQueue(message);
-        }
+        SMessage  message(type, dt.toTime_t(), context.category, msg, sourcePosition);
+        writeQueue(message);
+    }
+
+    emit logViewerLog(type, msg);
+}
+
+// --- File target ------------------------------------------------------------
+
+void Logger::setLogDirectory(const QString& directory) {
+    m_logDirectory = directory;
+    m_fileEnabled = !directory.isEmpty();
+
+    if (m_fileEnabled) {
+        rotateLogFile();
+    } else {
+        close();
     }
 }
 
-void Logger::messageOutput(::QtMsgType type, const QMessageLogContext& context, const QString& msg) {
-    if (s_instance != nullptr) {
-        s_instance->processMessage(type, context.category, context.file, context.line, msg);
+void Logger::setFileEnabled(bool fileLogging) {
+    if (m_fileEnabled == fileLogging) {
+        return;
+    }
+
+    if (fileLogging && m_logDirectory.isEmpty()) {
+        qCWarning(lcLogger) << "Cannot enable file logging without a log directory. Call setLogDirectory first!";
+        return;
+    }
+
+    m_fileEnabled = fileLogging;
+
+    if (m_fileEnabled) {
+        rotateLogFile();
+    } else {
+        close();
     }
 }
 
-void Logger::writeFile(const SMessage& message, const QDateTime& dt) {
-    int day = dt.date().day();
-    if (day != m_lastDay || m_file == nullptr) {
-        m_lastDay = day;
-        if (m_file != nullptr) {
-            m_file->close();
-        }
-        m_file       = new QFile;
-        QString path = QString("%1/%2.log").arg(m_directory, dt.toString("yyyy-MM-dd-hh"));
-        m_file->setFileName(path);
-        m_file->open(QIODevice::Append | QIODevice::Text);
+void Logger::rotateLogFile() {
+    m_lastRotationDay = QDate::currentDate().day();
+
+    // logfiles are disabled if no log directory is set
+    if (m_logDirectory.isEmpty()) {
+        return;
     }
-    QString msg = QString("%1 %2 %3 %4 %5")
-                      .arg(dt.toString("dd.MM.yyyy hh:mm:ss"))
-                      .arg(s_msgTypeString[message.type])
-                      .arg(message.category)
-                      .arg(message.message)
-                      .arg(message.sourcePosition);
-    QTextStream out(m_file);
-    out.setCodec("UTF-8");
-    out << msg << endl;
+
+    // make sure log directory exists
+    QDir dir(m_logDirectory);
+    if (!dir.exists()) {
+        dir.mkpath(QStringLiteral("."));  // error handling in createNewLogFile if new log file cannot be created
+    }
+
+    // purge expired log files
+    purgeFiles(m_purgeFileHours);
+
+    // set new log file base name
+    QDateTime now = QDateTime::currentDateTime();
+    QString   newLogFileName = QString("yio-%1.log").arg(now.toString(QStringLiteral("yyyy-MM-dd")));
+
+    // log file search pattern to retrieve file number of current day
+    QRegExp regex(QStringLiteral(R"(yio-.*\.log\.(\d+))"));
+    int     fileCountSameDay = -1;
+
+    // Scan existing log files in log dir and determine current file number of the current day
+    for (const QString& file : getExistingLogFileNames(dir)) {
+        if (file.startsWith(newLogFileName) && regex.exactMatch(file)) {
+            fileCountSameDay = qMax(fileCountSameDay, regex.cap(1).toInt());
+        }
+    }
+
+    newLogFileName.append(QLatin1Char('.') + QString::number(fileCountSameDay + 1));
+
+    createNewLogFile(dir.filePath(newLogFileName));
+}
+
+int Logger::getFileCount() {
+    return getExistingLogFileNames(m_logDirectory).length();
+}
+
+int Logger::purgeFiles(int purgeHours) {
+    if (purgeHours <= 0) {
+        return 0;
+    }
+
+    QDir                 dir(m_logDirectory);
+    QString              currentLogFilePath = m_logFile.fileName();
+    QDateTime            now = QDateTime::currentDateTime();
+    int                  purgedFileCount = 0;
+    std::chrono::seconds expireSeconds(purgeHours * 60 * 60);
+
+    for (const QString& file : getExistingLogFileNames(dir)) {
+        QString filePath = dir.absoluteFilePath(file);
+        // only delete files if enabled and protect current log file
+        if (m_purgeFileHours > 0 && currentLogFilePath != filePath) {
+            QFileInfo fileInfo(filePath);
+            if (fileInfo.lastModified().addSecs(expireSeconds.count()) < now) {
+                if (dir.remove(file)) {
+                    purgedFileCount++;
+                }
+            }
+        }
+    }
+
+    if (purgedFileCount > 0) {
+        qCInfo(lcLogger) << "Log files purged:" << purgedFileCount;
+    }
+
+    return purgedFileCount;
+}
+
+QStringList Logger::getExistingLogFileNames(const QDir& logDir) {
+    return logDir.entryList(QStringList(QStringLiteral("yio-*.log.*")), QDir::Files, QDir::Name);
+}
+
+bool Logger::createNewLogFile(const QString& fileName) {
+    QMutexLocker locker(&m_mutex);
+    if (m_logStream) {
+        m_logStream.reset(nullptr);
+        m_logFile.close();
+    }
+
+    if (fileName.isEmpty()) {
+        return false;
+    }
+
+    m_logFile.setFileName(fileName);
+
+    if (!m_logFile.open(QIODevice::WriteOnly)) {
+        locker.unlock();  // avoid deadlock in case signal handler calls a log function
+        emit userError(QString(tr("Error creating log file '%1'.")).arg(fileName));
+        return false;
+    }
+
+    m_logStream.reset(new QTextStream(&m_logFile));
+    return true;
+}
+
+void Logger::writeFile(const QString& message) {
+    QMutexLocker lock(&m_mutex);
+
+    if (m_logStream) {
+        (*m_logStream) << message << endl;
+        m_logStream->flush();
+    }
+}
+
+// --- Queue target -----------------------------------------------------------
+
+void Logger::setQueueSize(int size) {
+    m_maxQueueSize = size;
+    setQueueEnabled(size > 0);
 }
 
 void Logger::writeQueue(const SMessage& message) {
-    QMutexLocker lock(&m_queueMutex);
+    static QMutex queueMutex;
+
+    QMutexLocker lock(&queueMutex);
     if (m_queue.count() >= m_maxQueueSize) {
         m_queue.dequeue();
     }
     m_queue.enqueue(message);
 }
 
-void Logger::writeConsole(const SMessage& message) {
-    QString msg = QString("%1 %2 %3 %4\n")
-                      .arg(s_msgTypeString[message.type])
-                      .arg(message.category)
-                      .arg(message.message)
-                      .arg(message.sourcePosition);
-    std::cout << msg.toStdString();  // goes to console
-    std::cout.flush();
-}
-
-void Logger::write(const QString& msg) { processMessage(QtMsgType::QtInfoMsg, "default", nullptr, 0, msg, true); }
-void Logger::writeDebug(const QString& msg) { processMessage(QtMsgType::QtDebugMsg, "default", nullptr, 0, msg, true); }
-void Logger::writeInfo(const QString& msg) { processMessage(QtMsgType::QtInfoMsg, "default", nullptr, 0, msg, true); }
-void Logger::writeWarning(const QString& msg) {
-    processMessage(QtMsgType::QtWarningMsg, "default", nullptr, 0, msg, true);
-}
-void Logger::purgeFiles(int purgeHours) {
-    QDir      dir(m_directory);
-    QDateTime dt          = QDateTime::currentDateTime();
-    dt                    = dt.addSecs(-purgeHours * 3600);
-    QStringList fileNames = dir.entryList(QStringList("*.log"), QDir::Files);
-    int         count     = 0;
-    for (QStringList::iterator i = fileNames.begin(); i != fileNames.end(); ++i) {
-        try {
-            int idx = i->lastIndexOf('.');
-            if (idx > 0) {
-                QDateTime filedt = QDateTime::fromString(i->left(idx), "yyyy-MM-dd-HH");
-                if (filedt < dt) {
-                    dir.remove(*i);
-                    count++;
-                }
-            }
-        } catch (...) {
-            qWarning() << "Error during purge";
-        }
-    }
-    if (count > 0) {
-        qInfo() << "Files purged : " << count;
-    }
-}
-int Logger::getFileCount() {
-    QDir        dir(m_directory);
-    QStringList fileNames = dir.entryList(QStringList("*.log"), QDir::Files);
-    return fileNames.length();
-}
-
-QJsonArray Logger::getQueuedMessages(int maxCount, int logLevel, const QStringList& categories) {
+QJsonArray Logger::getQueuedMessages(int maxCount, QtMsgType logLevel, const QStringList& categories) {
     QJsonArray array;
-    int        i         = 0;
-    quint16    levelMask = logLevelToMask(static_cast<QtMsgType>(logLevel));
+    int        i = 0;
     while (i < maxCount && !m_queue.isEmpty()) {
         SMessage msg = m_queue.dequeue();
-        if (!(levelMask & (1 << msg.type))) {
-            continue;
+        switch (logLevel) {
+            case QtFatalMsg:
+                continue;
+            case QtCriticalMsg:
+                if (msg.type != QtCriticalMsg) {
+                    continue;
+                }
+                break;
+            case QtWarningMsg:
+                if (msg.type == QtDebugMsg || msg.type == QtInfoMsg) {
+                    continue;
+                }
+                break;
+            case QtInfoMsg:
+                if (msg.type == QtDebugMsg) {
+                    continue;
+                }
+                break;
+            default: {
+            }  // all log messages
         }
+
         if (categories.length() > 0 && !categories.contains(msg.category)) {
             continue;
         }
@@ -280,28 +373,12 @@ QJsonArray Logger::getQueuedMessages(int maxCount, int logLevel, const QStringLi
     }
     return array;
 }
+
 QJsonObject Logger::getInformation() {
     QJsonObject info;
     info.insert("fileEnabled", m_fileEnabled);
     info.insert("queueEnabled", m_queueEnabled);
-    info.insert("consoleEnabled", m_consoleEnabled);
     info.insert("fileCount", getFileCount());
     info.insert("showSourcePos", m_showSource);
-    QJsonArray                         array;
-    QHashIterator<QString, SCategory*> i(m_categories);
-    int                                idx = 0;
-    while (i.hasNext()) {
-        i.next();
-        QJsonObject obj;
-        obj.insert("category", i.key());
-        obj.insert("level", i.value()->logLevel);
-        obj.insert("countDebug", i.value()->count[QtMsgType::QtDebugMsg]);
-        obj.insert("countInfo", i.value()->count[QtMsgType::QtInfoMsg]);
-        obj.insert("countCritical", i.value()->count[QtMsgType::QtCriticalMsg]);
-        obj.insert("countWarning", i.value()->count[QtMsgType::QtWarningMsg]);
-        obj.insert("countFatal", i.value()->count[QtMsgType::QtFatalMsg]);
-        array.insert(idx++, obj);
-    }
-    info.insert("categories", array);
     return info;
 }

--- a/sources/logger.h
+++ b/sources/logger.h
@@ -1,5 +1,6 @@
 /******************************************************************************
  *
+ * Copyright (C) 2020 Markus Zehnder <business@markuszehnder.ch>
  * Copyright (C) 2019 Christian Riedl <ric@rts.co.at>
  *
  * This file is part of the YIO-Remote software project.
@@ -22,91 +23,132 @@
 
 #pragma once
 
-#include <QDateTime>
+#include <QDir>
 #include <QFile>
 #include <QJsonArray>
 #include <QJsonObject>
-#include <QLoggingCategory>
 #include <QMutex>
 #include <QObject>
 #include <QQueue>
+#include <QSet>
+#include <QStringList>
 #include <QTextStream>
-
-#include "yio-interface/plugininterface.h"
 
 class Logger : public QObject {
     Q_OBJECT
 
  public:
-    // Unfortunately it is not possible to use QtMsgType as logLevel, using an int
-    Q_PROPERTY(int logLevel READ logLevel WRITE setLogLevel)  // default log level
-    Q_PROPERTY(bool fileEnabled READ fileEnabled WRITE setFileEnabled)
-    Q_PROPERTY(bool queueEnabled READ queueEnabled WRITE setQueueEnabled)
-    Q_PROPERTY(bool consoleEnabled READ consoleEnabled WRITE setConsoleEnabled)
-    Q_PROPERTY(bool showSourcePos READ showSourcePos WRITE setShowSourcePos)
+    static Logger* instance();
 
-    // write log functions intended for QML
-    Q_INVOKABLE void write(const QString& msg);
-    Q_INVOKABLE void writeDebug(const QString& msg);
-    Q_INVOKABLE void writeInfo(const QString& msg);
-    Q_INVOKABLE void writeWarning(const QString& msg);
+    /**
+     * @brief Sets the log level of the app.
+     * @details The log level is mapped to logging rules on logging categories prefixed with `yio.`
+     * @param logLevel DEBUG, INFO, WARN, CRIT, FATAL
+     */
+    void      setLogLevel(const QString& logLevel);
+    void      setLogLevel(QtMsgType logLevel);
+    QtMsgType logLevel() { return m_logLevel; }
 
-    Q_INVOKABLE int toMsgType(const QString& msgType);
+    QtMsgType toMsgType(const QString& logLevel) const;
 
-    // set category log level, if category is not existing it is created
-    Q_INVOKABLE void setCategoryLogLevel(const QString& category, int level);
-    Q_INVOKABLE int  getCategoryLogLevel(const QString& category);
+    /**
+     * @brief Adds custom log filter rules to the default rules defined in QT_LOGGING_RULES.
+     * @details The applied filter order is undefined! Dependent filters must be defined in the same set entry,
+     * separated by a newline. The custom rules are added after the default rules.
+     * Logging rules documentation: https://doc.qt.io/qt-5.12/qloggingcategory.html#logging-rules
+     */
+    void addLogRule(const QSet<QString>& rules);
+    void removeLogRule(const QSet<QString>& rules);
+    /**
+     * @brief Clears all custom log rules
+     */
+    void clearLogRules();
 
-    // important when a plugin is unloaded
-    Q_INVOKABLE void removeCategory(const QString& category);
+    void setDefaultHandlerEnabled(bool value) { m_defHandlerEnabled = value; }
+    bool isDefaultHandlerEnabled() { return m_defHandlerEnabled; }
 
-    // for use in QML or from YIO API
-    Q_INVOKABLE QJsonArray  getQueuedMessages(int maxCount, int logLevel, const QStringList& categories);
-    Q_INVOKABLE QJsonObject getInformation();
+    // -- File logging target
 
-    Q_INVOKABLE int  getFileCount();
-    Q_INVOKABLE void purgeFiles(int purgeHours);
+    /**
+     * @brief Sets the log file directory, if empty no log files will be written.
+     */
+    void setLogDirectory(const QString& directory);
+    /**
+     * @brief Sets the number of hours after which log files will be removed. 0 = disabled.
+     */
+    void setLogFilePurgeHours(int hours) { m_purgeFileHours = hours; }
 
-    // path :       directory for log file, if empty no log file
-    // logLevel :   default log level
-    // debug :      output to QtCreator DEBUG
-    // showSource : show qDebug ... source and line
-    // queueSize :  maximum Queue size
-    // purgeHours : purge at start
-    explicit Logger(const QString& path, QString logLevel = "DEBUG", bool console = true, bool showSource = false,
-                    int queueSize = 100, int purgeHours = 12, QObject* parent = nullptr);
-    ~Logger();
+    /**
+     * @brief Starts or stops the file logging target.
+     * @details A new log file is automatically created when enabled, otherwise the log file will be closed.
+     */
+    void setFileEnabled(bool fileLogging);
+    bool isFileEnabled() { return m_fileEnabled; }
 
-    QtMsgType      logLevel() { return m_logLevel; }
-    void           setLogLevel(int logLevel);
-    bool           fileEnabled() { return m_fileEnabled; }
-    void           setFileEnabled(bool value) { m_fileEnabled = value; }
-    bool           queueEnabled() { return m_queueEnabled; }
-    void           setQueueEnabled(bool value) { m_queueEnabled = value; }
-    bool           consoleEnabled() { return m_consoleEnabled; }
-    void           setConsoleEnabled(bool value) { m_consoleEnabled = value; }
-    bool           showSourcePos() { return m_showSource; }
-    void           setShowSourcePos(bool value) { m_showSource = value; }
-    static Logger* getInstance() { return s_instance; }
+    /**
+     * @brief Returns the number of written log files
+     */
+    int getFileCount();
 
-    // for use from C++ to register a Logging category
-    // used by integrations to register plugin logging
-    void defineLogCategory(const QString& category, int level, QLoggingCategory* loggingCategory = nullptr,
-                           PluginInterface* plugin = nullptr);
+    /**
+     * @brief Purges log files which are older than the given number of hours.
+     * The current log file will never be purged.
+     * @return The number of purged files.
+     */
+    int purgeFiles(int purgeHours);
+
+    // -- Queue logging target for YIO API use. TODO(zehnm) still required?
+
+    bool        isShowSourcePos() { return m_showSource; }
+    void        setShowSourcePos(bool value) { m_showSource = value; }
+    void        setQueueSize(int size);
+    bool        isQueueEnabled() { return m_queueEnabled; }
+    void        setQueueEnabled(bool value) { m_queueEnabled = value; }
+    QJsonArray  getQueuedMessages(int maxCount, QtMsgType logLevel, const QStringList& categories);
+    QJsonObject getInformation();
+
+ public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+    /**
+     * @brief Triggers file rotation
+     */
+    void rotateLogFile();
+
+ signals:
+    /**
+     * @brief This signal is emitted if an error occured which should be displayed to the user.
+     * @details Intended to connect to the notification handler to show a popup error to the user.
+     * @param errorMsg A human-readable description of the error.
+     */
+    void userError(const QString& errorMsg);
+
+    /**
+     * @brief This signal is emitted for every log message which is not filtered by a logging rule.
+     * @details Intended for a UI log viewer or to relay log messages to external system (e.g. web-configurator).
+     * @param type The log type
+     * @param logMsg The original log message.
+     */
+    void logViewerLog(QtMsgType type, const QString& logMsg);
 
  private:
-    struct SCategory {
-        explicit SCategory(QtMsgType logLevel, QLoggingCategory* logCategory = nullptr,
-                           PluginInterface* plugin = nullptr)
-            : logCategory(logCategory), plugin(plugin), logLevel(logLevel), logLevelMask(logLevelToMask(logLevel)) {
-            memset(count, 0, sizeof(count));
-        }
-        QLoggingCategory* logCategory;                      // logCategory
-        PluginInterface*  plugin;                           // plugin
-        QtMsgType         logLevel;                         // !!ored with overall log level
-        quint16           logLevelMask;                     // required because QtMsgType has strange sorting
-        quint16           count[QtMsgType::QtInfoMsg + 1];  // counts errors per msg type
-    };
+    // singleton class, may not be instantiated
+    explicit Logger(QObject* parent = nullptr);
+    ~Logger();
+
+    void close();
+
+    // custom Qt log message handler
+    static void yioMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString& msg);
+
+    // main log message processor
+    void processMessage(QtMsgType type, const QMessageLogContext& context, const QString& msg);
+
+    void setLogRules(const QSet<QString>& rules);
+
+    QStringList getExistingLogFileNames(const QDir& logDir);
+    bool        createNewLogFile(const QString& fileName);
+
+    void writeFile(const QString& message);
+
     struct SMessage {
         SMessage(QtMsgType type, uint timestamp, const QString& category, const QString& message,
                  const QString& sourcePosition)
@@ -118,30 +160,25 @@ class Logger : public QObject {
         QString   sourcePosition;
     };
 
-    void processMessage(QtMsgType type, const char* category, const char* source, int line, const QString& msg,
-                        bool writeanyHow = false);
-    void writeFile(const SMessage& message, const QDateTime& dt);
     void writeQueue(const SMessage& message);
-    void writeConsole(const SMessage& message);
 
-    static void    messageOutput(QtMsgType type, const QMessageLogContext& context, const QString& msg);
-    static quint16 logLevelToMask(QtMsgType logLevel);
+ private:
+    QtMsgType     m_logLevel;
+    QSet<QString> m_logRules;
+    bool          m_defHandlerEnabled;
 
-    static Logger*     s_instance;
-    static QStringList s_msgTypeString;    // Strings used for logging
-    static QtMsgType   s_msgTypeSorted[];  // required because QtMsgType has strange sorting
+    // file related logging
+    bool                        m_fileEnabled;      // Output to log file
+    int                         m_purgeFileHours;   // Log file expiration in hours
+    int                         m_lastRotationDay;  // Day of the month of last file rotation
+    QString                     m_logDirectory;     // Log file directory
+    QFile                       m_logFile;          // Current log file
+    QMutex                      m_mutex;            // Thread-safe file access
+    QScopedPointer<QTextStream> m_logStream;        // Log file output stream
 
-    QHash<QString, SCategory*> m_categories;  // categories
-    QtMsgType                  m_logLevel;    // overall log level
-    quint16          m_logLevelMask;          // overall log level mask, required because QtMsgType has strange sorting
-    bool             m_consoleEnabled;        // output to console
-    bool             m_fileEnabled;           // output to log file
-    bool             m_queueEnabled;          // output to queue for JSON API
-    bool             m_showSource;            // Show source file and line
-    int              m_lastDay;               // Every day we create a new file
-    int              m_maxQueueSize;          // Maximum Queue size
-    QString          m_directory;             // For files
-    QFile*           m_file;                  // File
-    QQueue<SMessage> m_queue;                 // Queue
-    QMutex           m_queueMutex;            // Locking for queue
+    // queue related logging
+    bool             m_queueEnabled;  // output to queue for JSON API
+    bool             m_showSource;    // Show source file and line in queue messages
+    int              m_maxQueueSize;  // Maximum queue size
+    QQueue<SMessage> m_queue;         // Queue
 };

--- a/sources/logging.cpp
+++ b/sources/logging.cpp
@@ -1,0 +1,76 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2020 Markus Zehnder <business@markuszehnder.ch>
+ *
+ * This file is part of the YIO-Remote software project.
+ *
+ * YIO-Remote software is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * YIO-Remote software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with YIO-Remote software. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *****************************************************************************/
+
+#include "logging.h"
+
+// Main modules
+Q_LOGGING_CATEGORY(lcApp, "yio.app");
+Q_LOGGING_CATEGORY(lcI18n, "yio.app.i18n");
+Q_LOGGING_CATEGORY(lcApi, "yio.api");
+Q_LOGGING_CATEGORY(lcPlugin, "yio.plugin");
+Q_LOGGING_CATEGORY(lcLogger, "yio.logger");
+Q_LOGGING_CATEGORY(lcMediaPlayer, "yio.mediaplayer");
+Q_LOGGING_CATEGORY(lcNotification, "yio.notification");
+
+// Entities
+Q_LOGGING_CATEGORY(lcEntity, "yio.entity");
+Q_LOGGING_CATEGORY(lcEntityRemote, "yio.entity.remote");
+
+// Updates
+Q_LOGGING_CATEGORY(lcOta, "yio.ota");
+Q_LOGGING_CATEGORY(lcOtaDownload, "yio.ota.download");
+
+// Configuration
+Q_LOGGING_CATEGORY(lcCfg, "yio.cfg");
+Q_LOGGING_CATEGORY(lcCfgJson, "yio.cfg.json");
+
+// Hardware
+Q_LOGGING_CATEGORY(lcHwFactory, "yio.hw.factory");
+Q_LOGGING_CATEGORY(lcBtnHandler, "yio.hw.btnhandler");
+Q_LOGGING_CATEGORY(lcTouch, "yio.hw.touchevent");
+Q_LOGGING_CATEGORY(lcStandby, "yio.hw.standby");
+
+Q_LOGGING_CATEGORY(lcBluetooth, "yio.bluetooth");
+Q_LOGGING_CATEGORY(lcWifi, "yio.wifi");
+Q_LOGGING_CATEGORY(lcWifiMock, "yio.wifi.mock");
+Q_LOGGING_CATEGORY(lcWifiWpaCtrl, "yio.wifi.wpactrl");
+Q_LOGGING_CATEGORY(lcWifiShellScript, "yio.wifi.script");
+
+// Hardware devices
+Q_LOGGING_CATEGORY(lcDevice, "yio.dev.device");
+Q_LOGGING_CATEGORY(lcApds9960, "yio.dev.apds9960");
+Q_LOGGING_CATEGORY(lcApds9960Gesture, "yio.dev.apds9960.gesture");
+Q_LOGGING_CATEGORY(lcApds9960Light, "yio.dev.apds9960.light");
+Q_LOGGING_CATEGORY(lcApds9960Prox, "yio.dev.apds9960.prox");
+Q_LOGGING_CATEGORY(lcDevPortExp, "yio.dev.portexp");
+Q_LOGGING_CATEGORY(lcDevHaptic, "yio.dev.haptic");
+Q_LOGGING_CATEGORY(lcDevBatCharger, "yio.dev.bat.charger");
+Q_LOGGING_CATEGORY(lcDevFuelGauge, "yio.dev.bat.fuelgauge");
+Q_LOGGING_CATEGORY(lcDevDisplay, "yio.dev.display");
+
+// OS environment
+Q_LOGGING_CATEGORY(lcEnv, "yio.env");
+Q_LOGGING_CATEGORY(lcSysInfo, "yio.env.sysinfo");
+Q_LOGGING_CATEGORY(lcService, "yio.env.srv");
+Q_LOGGING_CATEGORY(lcSystemd, "yio.env.srv.systemd");
+Q_LOGGING_CATEGORY(lcServiceMock, "yio.env.srv.mock");
+Q_LOGGING_CATEGORY(lcServiceWeb, "yio.env.srv.web");

--- a/sources/logging.h
+++ b/sources/logging.h
@@ -1,0 +1,72 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2020 Markus Zehnder <business@markuszehnder.ch>
+ *
+ * This file is part of the YIO-Remote software project.
+ *
+ * YIO-Remote software is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * YIO-Remote software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with YIO-Remote software. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *****************************************************************************/
+
+#pragma once
+
+#include <QtDebug>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(lcApp);
+Q_DECLARE_LOGGING_CATEGORY(lcI18n);
+Q_DECLARE_LOGGING_CATEGORY(lcApi);
+Q_DECLARE_LOGGING_CATEGORY(lcPlugin);
+Q_DECLARE_LOGGING_CATEGORY(lcLogger);
+Q_DECLARE_LOGGING_CATEGORY(lcMediaPlayer);
+Q_DECLARE_LOGGING_CATEGORY(lcNotification);
+
+Q_DECLARE_LOGGING_CATEGORY(lcEntity);
+Q_DECLARE_LOGGING_CATEGORY(lcEntityRemote);
+
+Q_DECLARE_LOGGING_CATEGORY(lcOta);
+Q_DECLARE_LOGGING_CATEGORY(lcOtaDownload);
+
+Q_DECLARE_LOGGING_CATEGORY(lcCfg);
+Q_DECLARE_LOGGING_CATEGORY(lcCfgJson);
+
+Q_DECLARE_LOGGING_CATEGORY(lcHwFactory);
+Q_DECLARE_LOGGING_CATEGORY(lcBtnHandler);
+Q_DECLARE_LOGGING_CATEGORY(lcTouch);
+Q_DECLARE_LOGGING_CATEGORY(lcStandby);
+
+Q_DECLARE_LOGGING_CATEGORY(lcBluetooth);
+Q_DECLARE_LOGGING_CATEGORY(lcWifi);
+Q_DECLARE_LOGGING_CATEGORY(lcWifiMock);
+Q_DECLARE_LOGGING_CATEGORY(lcWifiWpaCtrl);
+Q_DECLARE_LOGGING_CATEGORY(lcWifiShellScript);
+
+Q_DECLARE_LOGGING_CATEGORY(lcDevice);
+Q_DECLARE_LOGGING_CATEGORY(lcApds9960);
+Q_DECLARE_LOGGING_CATEGORY(lcApds9960Gesture);
+Q_DECLARE_LOGGING_CATEGORY(lcApds9960Light);
+Q_DECLARE_LOGGING_CATEGORY(lcApds9960Prox);
+Q_DECLARE_LOGGING_CATEGORY(lcDevPortExp);
+Q_DECLARE_LOGGING_CATEGORY(lcDevHaptic);
+Q_DECLARE_LOGGING_CATEGORY(lcDevBatCharger);
+Q_DECLARE_LOGGING_CATEGORY(lcDevFuelGauge);
+Q_DECLARE_LOGGING_CATEGORY(lcDevDisplay);
+
+Q_DECLARE_LOGGING_CATEGORY(lcEnv);
+Q_DECLARE_LOGGING_CATEGORY(lcSysInfo);
+Q_DECLARE_LOGGING_CATEGORY(lcService);
+Q_DECLARE_LOGGING_CATEGORY(lcSystemd);
+Q_DECLARE_LOGGING_CATEGORY(lcServiceMock);
+Q_DECLARE_LOGGING_CATEGORY(lcServiceWeb);

--- a/sources/notifications.h
+++ b/sources/notifications.h
@@ -27,7 +27,6 @@
 #include <QObject>
 #include <QQmlApplicationEngine>
 
-#include "logger.h"
 #include "yio-interface/notificationsinterface.h"
 
 class Notification {
@@ -89,7 +88,6 @@ class Notifications : public QObject, public NotificationsInterface {
 
     static Notifications * s_instance;
     QQmlApplicationEngine *m_engine;
-    QLoggingCategory       m_log;
 
     void show(int id);
 };

--- a/sources/standbycontrol.cpp
+++ b/sources/standbycontrol.cpp
@@ -22,12 +22,8 @@
 
 #include "standbycontrol.h"
 
-#include <QLoggingCategory>
-#include <QtDebug>
-
+#include "logging.h"
 #include "yio-interface/integrationinterface.h"
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "standbycontrol");
 
 StandbyControl *StandbyControl::s_instance = nullptr;
 
@@ -99,7 +95,7 @@ StandbyControl::StandbyControl(DisplayControl *displayControl, ProximitySensor *
         loadingScreen->setProperty("active", true);
     });
 
-    qCDebug(CLASS_LC) << "Standby Control intialized";
+    qCDebug(lcStandby) << "Standby Control intialized";
 }
 
 StandbyControl::~StandbyControl() { s_instance = nullptr; }
@@ -116,17 +112,17 @@ QObject *StandbyControl::getQMLInstance(QQmlEngine *engine, QJSEngine *scriptEng
 void StandbyControl::wakeup() {
     switch (mode()) {
         case (DIM): {
-            qCDebug(CLASS_LC) << "Wakeup from DIM";
+            qCDebug(lcStandby) << "Wakeup from DIM";
             readAmbientLight();
             setMode(ON);
         } break;
 
         case (STANDBY): {
-            qCDebug(CLASS_LC) << "Wakeup from STANDBY";
+            qCDebug(lcStandby) << "Wakeup from STANDBY";
 
             m_format.setSwapInterval(1);
             QSurfaceFormat::setDefaultFormat(m_format);
-            qCDebug(CLASS_LC) << "Changing swap interval to " << m_format.swapInterval();
+            qCDebug(lcStandby) << "Changing swap interval to " << m_format.swapInterval();
 
             // delay reading ambient light so the sensor is clear of your hand
             QTimer *timer = new QTimer(this);
@@ -154,11 +150,11 @@ void StandbyControl::wakeup() {
 
             // reset battery charging screen
             if (m_batteryFuelGauge->getIsCharging()) {
-                qCDebug(CLASS_LC()) << "Battery is charging";
+                qCDebug(lcStandby) << "Battery is charging";
                 QObject *showClock = m_config->getQMLObject("showClock");
                 QMetaObject::invokeMethod(showClock, "start", Qt::AutoConnection);
             } else {
-                qCDebug(CLASS_LC()) << "Battery not is charging";
+                qCDebug(lcStandby) << "Battery not is charging";
             }
 
             QTimer::singleShot(300, this, [=]() {
@@ -171,11 +167,11 @@ void StandbyControl::wakeup() {
         } break;
 
         case (WIFI_OFF): {
-            qCDebug(CLASS_LC) << "Wakeup from WIFI_OFF";
+            qCDebug(lcStandby) << "Wakeup from WIFI_OFF";
 
             m_format.setSwapInterval(1);
             QSurfaceFormat::setDefaultFormat(m_format);
-            qCDebug(CLASS_LC) << "Changing swap interval to " << m_format.swapInterval();
+            qCDebug(lcStandby) << "Changing swap interval to " << m_format.swapInterval();
 
             m_wifiControl->on();
 
@@ -293,7 +289,7 @@ void StandbyControl::onSecondsTimerTimeout() {
 
         // change mode
         setMode(DIM);
-        qCDebug(CLASS_LC) << "State set to DIM";
+        qCDebug(lcStandby) << "State set to DIM";
     }
 
     // STANDBY
@@ -328,9 +324,9 @@ void StandbyControl::onSecondsTimerTimeout() {
 
         m_format.setSwapInterval(60);
         QSurfaceFormat::setDefaultFormat(m_format);
-        qCDebug(CLASS_LC) << "Changing swap interval to " << m_format.swapInterval();
+        qCDebug(lcStandby) << "Changing swap interval to " << m_format.swapInterval();
 
-        qCDebug(CLASS_LC) << "State set to STANDBY";
+        qCDebug(lcStandby) << "State set to STANDBY";
     }
 
     // TURN OFF BLUETOOTH
@@ -356,13 +352,13 @@ void StandbyControl::onSecondsTimerTimeout() {
         m_wifiControl->off();
 
         setMode(WIFI_OFF);
-        qCDebug(CLASS_LC) << "State set to WIFI OFF";
+        qCDebug(lcStandby) << "State set to WIFI OFF";
     }
 
     // SHUTDOWN
     if (m_elapsedTime == m_shutDownTime && m_shutDownTime != 0 && (m_mode == STANDBY || m_mode == WIFI_OFF) &&
         m_batteryFuelGauge->getAveragePower() < 0 && !m_batteryFuelGauge->getIsCharging()) {
-        qCInfo(CLASS_LC) << "TIMER SHUTDOWN"
+        qCInfo(lcStandby) << "TIMER SHUTDOWN"
                          << "Average power:" << m_batteryFuelGauge->getAveragePower()
                          << "Is charging:" << m_batteryFuelGauge->getIsCharging();
 
@@ -385,7 +381,7 @@ void StandbyControl::onTouchDetected() {
 }
 
 void StandbyControl::onProximityDetected() {
-    qCDebug(CLASS_LC) << "Proximity detected";
+    qCDebug(lcStandby) << "Proximity detected";
     wakeup();
 }
 

--- a/sources/translation.cpp
+++ b/sources/translation.cpp
@@ -21,10 +21,7 @@
  *****************************************************************************/
 
 #include "translation.h"
-
-#include <QLoggingCategory>
-
-static Q_LOGGING_CATEGORY(CLASS_LC, "translation");
+#include "logging.h"
 
 TranslationHandler *TranslationHandler::s_instance = nullptr;
 
@@ -38,12 +35,12 @@ TranslationHandler::TranslationHandler(QQmlEngine *engine) {
 TranslationHandler::~TranslationHandler() { s_instance = nullptr; }
 
 void TranslationHandler::selectLanguage(QString language) {
-    qCDebug(CLASS_LC) << "Language selected:" << language;
+    qCDebug(lcI18n) << "Language selected:" << language;
 
     qGuiApp->removeTranslator(m_translator);
     m_translator->load(":/translations/" + language);
     qGuiApp->installTranslator(m_translator);
-    qCDebug(CLASS_LC) << "Installed translation for main app" << language;
+    qCDebug(lcI18n) << "Installed translation for main app" << language;
 
     // install plugin translations
     QList<QObject *> plugins = Integrations::getInstance()->getAllPlugins();
@@ -52,7 +49,7 @@ void TranslationHandler::selectLanguage(QString language) {
         if (pInterface) {
             qGuiApp->removeTranslator(pInterface->pluginTranslator());
             qGuiApp->installTranslator(pInterface->installTranslator(language));
-            qCDebug(CLASS_LC) << "Installed translation for plugin" << language << pInterface;
+            qCDebug(lcI18n) << "Installed translation for plugin" << language << pInterface;
         }
     }
 

--- a/sources/yioapi.cpp
+++ b/sources/yioapi.cpp
@@ -714,6 +714,9 @@ void YioAPI::processMessage(QString message) {
             } else if (type == "set_dark_mode") {
                 /// Set dark mode
                 apiSettingsSetDarkMode(client, id, map);
+            } else if (type == "log") {
+                /// Logger control
+                apiLoggerControl(client, id, map);
             }
 
         } else {

--- a/sources/yioapi.h
+++ b/sources/yioapi.h
@@ -166,4 +166,6 @@ class YioAPI : public YioAPIInterface {
     void apiSettingsSetLanguage(QWebSocket* client, const int& id, const QVariantMap& map);
     void apiSettingsSetAutoBrightness(QWebSocket* client, const int& id, const QVariantMap& map);
     void apiSettingsSetDarkMode(QWebSocket* client, const int& id, const QVariantMap& map);
+
+    void apiLoggerControl(QWebSocket* client, const int& id, const QVariantMap& map);
 };

--- a/translations/en_US.ts
+++ b/translations/en_US.ts
@@ -124,7 +124,7 @@ To learn more about the project, visit
 <context>
     <name>BluetoothControl</name>
     <message>
-        <location filename="../sources/bluetooth.cpp" line="41"/>
+        <location filename="../sources/bluetooth.cpp" line="39"/>
         <source>Bluetooth device was not found.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -383,32 +383,32 @@ To learn more about the project, visit
 <context>
     <name>CommandLineHandler</name>
     <message>
-        <location filename="../sources/commandlinehandler.cpp" line="45"/>
+        <location filename="../sources/commandlinehandler.cpp" line="42"/>
         <source>Use configuration profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/commandlinehandler.cpp" line="48"/>
+        <location filename="../sources/commandlinehandler.cpp" line="45"/>
         <source>Use configuration file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/commandlinehandler.cpp" line="49"/>
+        <location filename="../sources/commandlinehandler.cpp" line="46"/>
         <source>Use configuration schema file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/commandlinehandler.cpp" line="50"/>
+        <location filename="../sources/commandlinehandler.cpp" line="47"/>
         <source>Use hardware configuration file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/commandlinehandler.cpp" line="51"/>
+        <location filename="../sources/commandlinehandler.cpp" line="48"/>
         <source>Use hardware configuration schema file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/commandlinehandler.cpp" line="55"/>
+        <location filename="../sources/commandlinehandler.cpp" line="52"/>
         <source>Validate json configuration files and exit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -535,12 +535,12 @@ to fix the problem.</source>
 <context>
     <name>FileDownload</name>
     <message>
-        <location filename="../sources/filedownload.cpp" line="114"/>
+        <location filename="../sources/filedownload.cpp" line="112"/>
         <source>Not enough free space (%1 MB).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/filedownload.cpp" line="121"/>
+        <location filename="../sources/filedownload.cpp" line="119"/>
         <source>Destination file already exists</source>
         <translation type="unfinished"></translation>
     </message>
@@ -590,29 +590,37 @@ to set up YIO remote</source>
 <context>
     <name>JsonFile</name>
     <message>
-        <location filename="../sources/jsonfile.cpp" line="80"/>
-        <location filename="../sources/jsonfile.cpp" line="133"/>
+        <location filename="../sources/jsonfile.cpp" line="78"/>
+        <location filename="../sources/jsonfile.cpp" line="131"/>
         <source>empty name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/jsonfile.cpp" line="86"/>
+        <location filename="../sources/jsonfile.cpp" line="84"/>
         <source>empty data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/jsonfile.cpp" line="97"/>
+        <location filename="../sources/jsonfile.cpp" line="95"/>
         <source>cannot open file &apos;%1&apos; for writing: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/jsonfile.cpp" line="140"/>
+        <location filename="../sources/jsonfile.cpp" line="138"/>
         <source>cannot open file &apos;%1&apos; for reading: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/jsonfile.cpp" line="149"/>
+        <location filename="../sources/jsonfile.cpp" line="147"/>
         <source>invalid JSON file &apos;%1&apos; at offset %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Logger</name>
+    <message>
+        <location filename="../sources/logger.cpp" line="300"/>
+        <source>Error creating log file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -713,7 +721,7 @@ to set up YIO remote</source>
 <context>
     <name>QGuiApplication</name>
     <message>
-        <location filename="../sources/main.cpp" line="210"/>
+        <location filename="../sources/main.cpp" line="216"/>
         <source>Factory reset failed.
  %1</source>
         <translation type="unfinished"></translation>
@@ -722,7 +730,7 @@ to set up YIO remote</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../sources/hardware/wifi_control.h" line="37"/>
+        <location filename="../sources/hardware/wifi_control.h" line="36"/>
         <source>WiFi device was not found.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1046,52 +1054,52 @@ Remote configuration after restarting the remote.</source>
 <context>
     <name>SoftwareUpdate</name>
     <message>
-        <location filename="../sources/softwareupdate.cpp" line="165"/>
+        <location filename="../sources/softwareupdate.cpp" line="163"/>
         <source>Cannot connect to the update server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/softwareupdate.cpp" line="196"/>
+        <location filename="../sources/softwareupdate.cpp" line="194"/>
         <source>Invalid request.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/softwareupdate.cpp" line="199"/>
+        <location filename="../sources/softwareupdate.cpp" line="197"/>
         <source>Unsupported device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/softwareupdate.cpp" line="202"/>
+        <location filename="../sources/softwareupdate.cpp" line="200"/>
         <source>Service currently not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/softwareupdate.cpp" line="205"/>
+        <location filename="../sources/softwareupdate.cpp" line="203"/>
         <source>Request error %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/softwareupdate.cpp" line="209"/>
+        <location filename="../sources/softwareupdate.cpp" line="207"/>
         <source>Software update:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/softwareupdate.cpp" line="226"/>
+        <location filename="../sources/softwareupdate.cpp" line="224"/>
         <source>New software is available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/softwareupdate.cpp" line="226"/>
+        <location filename="../sources/softwareupdate.cpp" line="224"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/softwareupdate.cpp" line="243"/>
+        <location filename="../sources/softwareupdate.cpp" line="241"/>
         <source>The remote needs to be at least 50% battery to perform updates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/softwareupdate.cpp" line="303"/>
+        <location filename="../sources/softwareupdate.cpp" line="301"/>
         <source>Download failed: %1</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Rewrite of the logger component and logger category refactoring.

- Replaced custom category logging and hard coded message format with "Qt way" concepts:
  - Supporting Qt logging rules in env variable `QT_LOGGING_RULES`.
     https://doc.qt.io/qt-5.12/qloggingcategory.html#logging-rules
  - Supporting Qt message format in env variable `QT_MESSAGE_PATTERN`.
    https://doc.qt.io/qt-5.12/qtglobal.html#qSetMessagePattern
  - Using default message handler for console logging and journald if available.
    Set `QT_LOGGING_TO_CONSOLE=0` to use journald on Linux.
  - See [Qt Logging Framework presentation](https://www.kdab.com/wp-content/uploads/stories/slides/Day2/KaiKoehne_Qt%20Logging%20Framework%2016_9_0.pdf) for more information.
- Refactored logging categories with common `yio.` prefix and sub categories for easy filtering with logging rules.
- Single error and user notification  if log file creation failed without further log error spam.
- Thread safe file logging.
- Log file naming: `yio-YYYY-MM-DD.log.n`
  - Rollover at midnight
  - Rollover at app (re-)start
  - `n`: file counter if multiple log files are created for the same day, e.g. after a reboot or app update.
  - For simplicity reasons the first log file of the day starts with `.0`.

This change got bigger than expected, important parts for the PR review are:

- Logging categories defined in `Logging.cpp`

      // Main modules
      Q_LOGGING_CATEGORY(lcApp, "yio.app");
      Q_LOGGING_CATEGORY(lcI18n, "yio.app.i18n");
      Q_LOGGING_CATEGORY(lcApi, "yio.api");
      Q_LOGGING_CATEGORY(lcPlugin, "yio.plugin");
      Q_LOGGING_CATEGORY(lcLogger, "yio.logger");
      Q_LOGGING_CATEGORY(lcMediaPlayer, "yio.mediaplayer");
      Q_LOGGING_CATEGORY(lcNotification, "yio.notification");
      // Entities
      Q_LOGGING_CATEGORY(lcEntity, "yio.entity");
      Q_LOGGING_CATEGORY(lcEntityRemote, "yio.entity.remote");
      // Updates
      Q_LOGGING_CATEGORY(lcOta, "yio.ota");
      Q_LOGGING_CATEGORY(lcOtaDownload, "yio.ota.download");
      // Configuration
      Q_LOGGING_CATEGORY(lcCfg, "yio.cfg");
      Q_LOGGING_CATEGORY(lcCfgJson, "yio.cfg.json");
      // Hardware
      Q_LOGGING_CATEGORY(lcHwFactory, "yio.hw.factory");
      Q_LOGGING_CATEGORY(lcBtnHandler, "yio.hw.btnhandler");
      Q_LOGGING_CATEGORY(lcTouch, "yio.hw.touchevent");
      Q_LOGGING_CATEGORY(lcStandby, "yio.hw.standby");
      Q_LOGGING_CATEGORY(lcBluetooth, "yio.bluetooth");
      Q_LOGGING_CATEGORY(lcWifi, "yio.wifi");
      Q_LOGGING_CATEGORY(lcWifiMock, "yio.wifi.mock");
      Q_LOGGING_CATEGORY(lcWifiWpaCtrl, "yio.wifi.wpactrl");
      Q_LOGGING_CATEGORY(lcWifiShellScript, "yio.wifi.script");
      // Hardware devices
      Q_LOGGING_CATEGORY(lcDevice, "yio.dev.device");
      Q_LOGGING_CATEGORY(lcApds9960, "yio.dev.apds9960");
      Q_LOGGING_CATEGORY(lcApds9960Gesture, "yio.dev.apds9960.gesture");
      Q_LOGGING_CATEGORY(lcApds9960Light, "yio.dev.apds9960.light");
      Q_LOGGING_CATEGORY(lcApds9960Prox, "yio.dev.apds9960.prox");
      Q_LOGGING_CATEGORY(lcDevPortExp, "yio.dev.portexp");
      Q_LOGGING_CATEGORY(lcDevHaptic, "yio.dev.haptic");
      Q_LOGGING_CATEGORY(lcDevBatCharger, "yio.dev.bat.charger");
      Q_LOGGING_CATEGORY(lcDevFuelGauge, "yio.dev.bat.fuelgauge");
      Q_LOGGING_CATEGORY(lcDevDisplay, "yio.dev.display");
      // OS environment
      Q_LOGGING_CATEGORY(lcEnv, "yio.env");
      Q_LOGGING_CATEGORY(lcSysInfo, "yio.env.sysinfo");
      Q_LOGGING_CATEGORY(lcService, "yio.env.srv");
      Q_LOGGING_CATEGORY(lcSystemd, "yio.env.srv.systemd");
      Q_LOGGING_CATEGORY(lcServiceMock, "yio.env.srv.mock");
      Q_LOGGING_CATEGORY(lcServiceWeb, "yio.env.srv.web");

- Default log message format in `Logger.cpp`

      %{time yyyy-MM-dd hh:mm:ss:zzz t} %{if-debug}DEBUG%{endif}%{if-info}INFO %{endif}%{if-warning}WARN 
      %{endif}%{if-critical}CRIT %{endif}%{if-fatal}FATAL%{endif} [%{category}]:\t%{message}\t[%{file}:%{line}]

- Log file naming and rollover behaviour
  Example with 3 app restarts yesterday and a rollover at midnight:

      yio-2020-10-14.log.0
      yio-2020-10-14.log.1
      yio-2020-10-14.log.2
      yio-2020-10-15.log.0

This closes #369