### PR TITLE
Bluetooth dock setup improvements

### DIFF
--- a/setup/SetupStep8.qml
+++ b/setup/SetupStep8.qml
@@ -51,6 +51,13 @@ Item {
             api.discoverNetworkServices("_yio-dock-api._tcp");
             mdnsDiscoveryTimeout.start();
         }
+
+        onDockSetupFailed: {
+            bluetoothDiscoveryTimeout.stop();
+
+            _swipeView.dockSuccess = false;
+            _swipeView.incrementCurrentIndex();
+        }
     }
 
     Connections {
@@ -92,7 +99,7 @@ Item {
     Timer {
         id: bluetoothDiscoveryTimeout
         running: _currentItem
-        interval: 20000
+        interval: 30000
         repeat: false
 
         onTriggered: {
@@ -104,7 +111,7 @@ Item {
     Timer {
         id: mdnsDiscoveryTimeout
         running: false
-        interval: 20000
+        interval: 30000
         repeat: false
 
         onTriggered: {

--- a/sources/bluetooth.h
+++ b/sources/bluetooth.h
@@ -32,33 +32,46 @@
 
 class BluetoothControl : public QObject {
     Q_OBJECT
+    Q_PROPERTY(bool enabled READ isEnabled WRITE setEnabled NOTIFY bluetoothStatusChanged)
 
  public:
     explicit BluetoothControl(QObject *parent = nullptr);
-    virtual ~BluetoothControl() {}
+    ~BluetoothControl();
 
-    void turnOn();
-    void turnOff();
+    bool isEnabled();
+    void setEnabled(bool enabled);
 
  signals:
-    void dockFound(QString name);
+    void bluetoothStatusChanged();
+
+    void dockFound(const QString &name);
+    void dockPaired(const QString &address);
+    void dockConnected(const QString &address, const QString &serviceUuid);
+
     void dockMessageSent();
+    void dockSetupFailed();
 
  public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
     void lookForDocks();
+    void sendCredentialsToDock(const QString &msg);
 
  private slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
     void onDeviceDiscovered(const QBluetoothDeviceInfo &device);
     void onDiscoveryFinished();
-    void sendCredentialsToDock(const QString &msg);
     void onPairingDone(const QBluetoothAddress &address, QBluetoothLocalDevice::Pairing pairing);
+    void onPairingError(QBluetoothLocalDevice::Error error);
     void onDockConnected();
-    void onSocketError(QBluetoothSocket::SocketError error);
+    void onDockSocketError(QBluetoothSocket::SocketError error);
+
+ private:
+    void close();
+    void dockSetupError();
 
  private:
     QBluetoothDeviceDiscoveryAgent *m_discoveryAgent;
     QBluetoothLocalDevice           m_localDevice;
 
+    // FIXME support multiple devices
     QBluetoothAddress m_dockAddress;
     QBluetoothUuid    m_dockServiceUuid;
     QBluetoothSocket *m_dockSocket;

--- a/sources/bluetooth.h
+++ b/sources/bluetooth.h
@@ -46,11 +46,14 @@ class BluetoothControl : public QObject {
 
  public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
     void lookForDocks();
+
+ private slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
     void onDeviceDiscovered(const QBluetoothDeviceInfo &device);
     void onDiscoveryFinished();
     void sendCredentialsToDock(const QString &msg);
-    void onDockConnected();
     void onPairingDone(const QBluetoothAddress &address, QBluetoothLocalDevice::Pairing pairing);
+    void onDockConnected();
+    void onSocketError(QBluetoothSocket::SocketError error);
 
  private:
     QBluetoothDeviceDiscoveryAgent *m_discoveryAgent;

--- a/sources/bluetooth.h
+++ b/sources/bluetooth.h
@@ -58,6 +58,7 @@ class BluetoothControl : public QObject {
  private slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
     void onDeviceDiscovered(const QBluetoothDeviceInfo &device);
     void onDiscoveryFinished();
+    void onPairingDisplayConfirmation(const QBluetoothAddress &address, QString pin);
     void onPairingDone(const QBluetoothAddress &address, QBluetoothLocalDevice::Pairing pairing);
     void onPairingError(QBluetoothLocalDevice::Error error);
     void onDockConnected();

--- a/translations/en_US.ts
+++ b/translations/en_US.ts
@@ -124,7 +124,7 @@ To learn more about the project, visit
 <context>
     <name>BluetoothControl</name>
     <message>
-        <location filename="../sources/bluetooth.cpp" line="39"/>
+        <location filename="../sources/bluetooth.cpp" line="40"/>
         <source>Bluetooth device was not found.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -721,7 +721,7 @@ to set up YIO remote</source>
 <context>
     <name>QGuiApplication</name>
     <message>
-        <location filename="../sources/main.cpp" line="217"/>
+        <location filename="../sources/main.cpp" line="221"/>
         <source>Factory reset failed.
  %1</source>
         <translation type="unfinished"></translation>
@@ -976,7 +976,7 @@ a power source and wait until it starts blinking.
 <context>
     <name>SetupStep8</name>
     <message>
-        <location filename="../setup/SetupStep8.qml" line="136"/>
+        <location filename="../setup/SetupStep8.qml" line="143"/>
         <source>Setting up your YIO Dock</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
The Bluetooth pairing with the dock didn't work anymore with the updated Bluez stack on remote-os v1.
It now requires to handle the `QBluetoothLocalDevice::pairingDisplayConfirmation` signal, otherwise paring is rejected.

Further improvements:
- `dockSetupFailed` signal for UI to indicate immediate failure to avoid waiting for timeout
- Enhanced (error) logging
- Fixed QBluetoothLocalDevice signal handling: only setup once
- Potential memory leak fixes

I'm not sure yet about the discovery timeouts. I've increased them from 20s to 30s. @martonborzak any experiences in your tests?
Most likely 20s is enough on the RPi, since the remote needs to be pretty close to the dock and discovers it within seconds. Discovery times on other operating systems were longer in my tests, but they are not really the target...

The `BluetoothControl` class needs a major overhaul so it can be used for multiple devices and integrated into the system UI menu for dock discovery, setup and update.
With this PR I'd like to get the pairing fix into the next release, before I continue rewriting Bluetooth handling.