### PR TITLE
Initial setup: clear networks before joining

### DIFF
--- a/setup/SetupStep3.qml
+++ b/setup/SetupStep3.qml
@@ -28,11 +28,15 @@ import WifiControl 1.0
 
 import "qrc:/basic_ui" as BasicUI
 
+// TODO(marton) back swipe or button to choose language / country setting again
 Item {
     id: container
     width: 480; height: 800
 
     Component.onCompleted: {
+        // TODO(marton) check if Wifi connection is already established and ask user to use it, or to set it up again.
+        //              This state can happen through a reboot during a previous setup process.
+        // Connection check: wifi.wifiStatus.connected
         networkScanTimer.start();
     }
 

--- a/setup/SetupStep4.qml
+++ b/setup/SetupStep4.qml
@@ -46,6 +46,7 @@ Rectangle {
         swipeViewObj.parent.parent.wifiPassword = passwordField.text;
         swipeViewObj.parent.parent.wifiSsid = name;
 
+        wifi.clearConfiguredNetworks();
         wifi.join(name, passwordField.text, security);
         inputPanel.active = false;
         container.state = "closed";

--- a/setup/SetupStep4Other.qml
+++ b/setup/SetupStep4Other.qml
@@ -53,6 +53,7 @@ Rectangle {
             security = WifiSecurity.DEFAULT;
         }
 
+        wifi.clearConfiguredNetworks();
         wifi.join(name, passwordField.text, security);
         inputPanel.active = false;
         container.state = "closed";

--- a/sources/hardware/linux/wifi_wpasupplicant.cpp
+++ b/sources/hardware/linux/wifi_wpasupplicant.cpp
@@ -170,6 +170,9 @@ bool WifiWpaSupplicant::clearConfiguredNetworks() {
 
     qCInfo(lcWifiWpaCtrl) << "All networks removed and disconnected";
 
+    // avoid deadlock.
+    // DISCONNECT doc states: "Disconnect and wait for REASSOCIATE or RECONNECT command before connecting."
+    controlRequest("RECONNECT");
     return true;
 }
 

--- a/sources/hardware/linux/wifi_wpasupplicant.cpp
+++ b/sources/hardware/linux/wifi_wpasupplicant.cpp
@@ -158,22 +158,18 @@ bool WifiWpaSupplicant::clearConfiguredNetworks() {
 
     setConnected(false);
 
-    if (!controlRequest("REMOVE_NETWORK all")) {
-        return false;
+    bool ret = false;
+    if (controlRequest("REMOVE_NETWORK all") && saveConfiguration()) {
+        stopScanTimer();
+
+        qCInfo(lcWifiWpaCtrl) << "Disconnected, all networks removed and cleared configuration";
+        ret = true;
     }
-
-    if (!saveConfiguration()) {
-        return false;
-    }
-
-    stopScanTimer();
-
-    qCInfo(lcWifiWpaCtrl) << "All networks removed and disconnected";
 
     // avoid deadlock.
     // DISCONNECT doc states: "Disconnect and wait for REASSOCIATE or RECONNECT command before connecting."
     controlRequest("RECONNECT");
-    return true;
+    return ret;
 }
 
 bool WifiWpaSupplicant::join(const QString& ssid, const QString& password, WifiSecurity::Enum security) {

--- a/translations/en_US.ts
+++ b/translations/en_US.ts
@@ -124,7 +124,7 @@ To learn more about the project, visit
 <context>
     <name>BluetoothControl</name>
     <message>
-        <location filename="../sources/bluetooth.cpp" line="40"/>
+        <location filename="../sources/bluetooth.cpp" line="46"/>
         <source>Bluetooth device was not found.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -721,7 +721,7 @@ to set up YIO remote</source>
 <context>
     <name>QGuiApplication</name>
     <message>
-        <location filename="../sources/main.cpp" line="221"/>
+        <location filename="../sources/main.cpp" line="220"/>
         <source>Factory reset failed.
  %1</source>
         <translation type="unfinished"></translation>
@@ -851,17 +851,17 @@ Navigate your internet browser to: http://</source>
 <context>
     <name>SetupStep3</name>
     <message>
-        <location filename="../setup/SetupStep3.qml" line="63"/>
+        <location filename="../setup/SetupStep3.qml" line="67"/>
         <source>Wi-Fi setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../setup/SetupStep3.qml" line="74"/>
+        <location filename="../setup/SetupStep3.qml" line="78"/>
         <source>Select a Wi-Fi network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../setup/SetupStep3.qml" line="166"/>
+        <location filename="../setup/SetupStep3.qml" line="170"/>
         <source>Join other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -869,18 +869,18 @@ Navigate your internet browser to: http://</source>
 <context>
     <name>SetupStep4</name>
     <message>
-        <location filename="../setup/SetupStep4.qml" line="97"/>
+        <location filename="../setup/SetupStep4.qml" line="98"/>
         <source>Enter password for
 &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../setup/SetupStep4.qml" line="115"/>
+        <location filename="../setup/SetupStep4.qml" line="116"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../setup/SetupStep4.qml" line="174"/>
+        <location filename="../setup/SetupStep4.qml" line="175"/>
         <source>Join</source>
         <translation type="unfinished"></translation>
     </message>
@@ -976,7 +976,7 @@ a power source and wait until it starts blinking.
 <context>
     <name>SetupStep8</name>
     <message>
-        <location filename="../setup/SetupStep8.qml" line="143"/>
+        <location filename="../setup/SetupStep8.qml" line="144"/>
         <source>Setting up your YIO Dock</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Make sure all configured networks are cleared before connecting to the selected network.
Otherwise one might end up with multiple network configurations and connect to the wrong network.

@martonborzak please check if I caught all WiFi join operations in the setup flow.

This closes #511