### PR TITLE
chore: Remove cpplint workaround for Qt signals

### DIFF
--- a/components/media_player/sources/utils_mediaplayer.h
+++ b/components/media_player/sources/utils_mediaplayer.h
@@ -43,7 +43,7 @@ class MediaPlayerUtilsImageProvider : public QObject, public QQuickImageProvider
 
     QImage requestImage(const QString& id, QSize* size, const QSize& requestedSize) override;
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     void updateImage(const QImage& image);
 
  signals:
@@ -61,7 +61,7 @@ class MediaPlayerUtilsWorker : public QObject {
     explicit MediaPlayerUtilsWorker(QObject* parent = nullptr);
     ~MediaPlayerUtilsWorker();
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     void generateImages(const QString& url);
     void generateImagesReply();
 
@@ -94,7 +94,7 @@ class MediaPlayerUtils : public QObject {
     void setImageURL(QString url);
     void setEnabled(bool value);
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     void onProcessingDone(const QColor& pixelColor, const QImage& image);
 
  signals:

--- a/sources/bluetooth.h
+++ b/sources/bluetooth.h
@@ -51,11 +51,11 @@ class BluetoothControl : public QObject {
     void dockMessageSent();
     void dockSetupFailed();
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     void lookForDocks();
     void sendCredentialsToDock(const QString &msg);
 
- private slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ private slots:
     void onDeviceDiscovered(const QBluetoothDeviceInfo &device);
     void onDiscoveryFinished();
     void onPairingDisplayConfirmation(const QBluetoothAddress &address, QString pin);

--- a/sources/factoryreset.h
+++ b/sources/factoryreset.h
@@ -38,7 +38,7 @@ class FactoryReset : public QObject {
     bool    isSupported() const;
     QString getError() const { return m_error; }
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     void performReset();
 
  signals:

--- a/sources/filedownload.h
+++ b/sources/filedownload.h
@@ -94,7 +94,7 @@ class FileDownload : public QObject {
      */
     void downloadQueueEmpty();
 
- private slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ private slots:
     void startNextDownload();
     void onDownloadProgress(qint64 bytesReceived, qint64 bytesTotal);
     void onDownloadError(QNetworkReply::NetworkError error);

--- a/sources/fileio.h
+++ b/sources/fileio.h
@@ -29,7 +29,7 @@
 class FileIO : public QObject {
     Q_OBJECT
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     bool write(const QString& source, const QString& data) {
         if (source.isEmpty())
             return false;

--- a/sources/hardware/batteryfuelgauge.h
+++ b/sources/hardware/batteryfuelgauge.h
@@ -60,7 +60,7 @@ class BatteryFuelGauge : public Device {
 
     int getCapacity() { return m_capacity; }
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     virtual void updateBatteryValues() = 0;
 
  signals:

--- a/sources/hardware/buttonhandler.h
+++ b/sources/hardware/buttonhandler.h
@@ -80,7 +80,7 @@ class ButtonHandler : public QObject {
     YioAPI*               m_api;
     bool                  m_resetButtonsPressed;
 
- private slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ private slots:
     void onInterrupt(int event);
     void onYIOAPIPressed(QString button);
     void onYIOAPIReleased(QString button);

--- a/sources/hardware/hardwarefactory.h
+++ b/sources/hardware/hardwarefactory.h
@@ -177,7 +177,7 @@ class HardwareFactory : public QObject {
      */
     virtual bool buildDevices(const QVariantMap& config) = 0;
 
- protected slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ protected slots:
     /**
      * @brief Error callback function for device drivers. InitializationError and CommunicationError are propagated as
      * user notifications.

--- a/sources/hardware/linux/arm/bq27441.h
+++ b/sources/hardware/linux/arm/bq27441.h
@@ -117,7 +117,7 @@ class BQ27441 : public BatteryFuelGauge {
     // Extended Data Commands
     uint16_t getOpConfig();
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     void  updateBatteryValues() override;
 
     // Device interface

--- a/sources/hardware/linux/arm/displaycontrol_yio.h
+++ b/sources/hardware/linux/arm/displaycontrol_yio.h
@@ -89,7 +89,7 @@ class DisplayControlYioThread : public QObject {
  private:
     void spi_screenreg_set(int32_t Addr, int32_t Data0, int32_t Data1);
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     void setBrightness(int from, int to);
     void enterStandby();
     void leaveStandby();

--- a/sources/hardware/linux/wifi_shellscripts.h
+++ b/sources/hardware/linux/wifi_shellscripts.h
@@ -71,7 +71,7 @@ class WifiShellScripts : public WifiControl {
 
     void setScriptTimeout(int scriptTimeoutMs) { m_scriptTimeout = scriptTimeoutMs; }
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
 
     void on() override;
     void off() override;

--- a/sources/hardware/linux/wifi_wpasupplicant.h
+++ b/sources/hardware/linux/wifi_wpasupplicant.h
@@ -119,12 +119,12 @@ class WifiWpaSupplicant : public WifiControl {
      */
     void authenticationRequest(QString type, int networkId, QString text);
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
 
     void on() override;
     void off() override;
 
- protected slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ protected slots:
 
     /**
      * @brief p_networkJoinTimer slot to verify network join status.

--- a/sources/hardware/mock/batteryfuelgauge_mock.h
+++ b/sources/hardware/mock/batteryfuelgauge_mock.h
@@ -51,6 +51,6 @@ class BatteryFuelGaugeMock : public BatteryFuelGauge {
     bool    getIsCharging() override { return false; }  // to test charging screen: return true
     float   remainingLife() override { return 2; }
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     void updateBatteryValues() override {};
 };

--- a/sources/hardware/mock/wifi_mock.h
+++ b/sources/hardware/mock/wifi_mock.h
@@ -50,7 +50,7 @@ class WifiMock : public WifiControl {
     void       setCountryCode(const QString &countryCode) override;
     WifiStatus wifiStatus() const override;
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     void on() override;
     void off() override;
 

--- a/sources/hardware/wifi_control.h
+++ b/sources/hardware/wifi_control.h
@@ -204,7 +204,7 @@ class WifiControl : public QObject {
      */
     void joinError(WifiControl::JoinError error);
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     /**
      * @brief Enable WiFi device
      */

--- a/sources/integrations/integrations.h
+++ b/sources/integrations/integrations.h
@@ -90,7 +90,7 @@ class Integrations : public QObject, IntegrationsInterface {
     void listChanged();
     void loadComplete();
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     void onCreateDone(QMap<QObject*, QVariant> map);
 
  private:

--- a/sources/jsonfile.h
+++ b/sources/jsonfile.h
@@ -94,7 +94,7 @@ class JsonFile : public QObject {
  signals:
     void nameChanged(const QString &name);
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     /**
      * @brief setName Sets the full file name
      * @param name The file name including path

--- a/sources/logger.h
+++ b/sources/logger.h
@@ -107,7 +107,7 @@ class Logger : public QObject {
     QJsonArray  getQueuedMessages(int maxCount, QtMsgType logLevel, const QStringList& categories);
     QJsonObject getInformation();
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     /**
      * @brief Triggers file rotation
      */

--- a/sources/softwareupdate.h
+++ b/sources/softwareupdate.h
@@ -88,7 +88,7 @@ class SoftwareUpdate : public QObject {
     void downloadComplete();
     void downloadFailed();
 
- private slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ private slots:
     void onCheckForUpdateFinished(QNetworkReply* reply);
     void onDownloadProgress(int id, qint64 bytesReceived, qint64 bytesTotal, const QString& speed);
     void onDownloadComplete(int id, const QString& filePath);

--- a/sources/standbycontrol.h
+++ b/sources/standbycontrol.h
@@ -121,7 +121,7 @@ class StandbyControl : public QObject {
     // The default interval is 1.
     QSurfaceFormat m_format = QSurfaceFormat::defaultFormat();
 
- private slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ private slots:
     void onSecondsTimerTimeout();
     void loadSettings();
     void onTouchDetected();

--- a/sources/yioapi.h
+++ b/sources/yioapi.h
@@ -80,7 +80,7 @@ class YioAPI : public YioAPIInterface {
     void buttonPressed(QString button);
     void buttonReleased(QString button);
 
- public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+ public slots:
     void onClosed();
     void onNewConnection();
     void processMessage(QString message);


### PR DESCRIPTION
The new cpplint version 1.5.2 finally supports Qt signal definitions.

- Removed all `// NOLINT` markers

This closes #521