### PR TITLE
fix: Integration loading error handling at startup

### DIFF
--- a/sources/integrations/integrations.cpp
+++ b/sources/integrations/integrations.cpp
@@ -52,14 +52,13 @@ Integrations::Integrations(const QString& pluginPath) : m_pluginPath(pluginPath)
 }
 
 QObject* Integrations::loadPlugin(const QString& type) {
-    Launcher* l = new Launcher();
-    QObject*  obj = l->loadPlugin(m_pluginPath, type);
+    Launcher launcher;
+    QObject*  obj = launcher.loadPlugin(m_pluginPath, type);
 
     // store the plugin objects
-    m_plugins.insert(type, obj);
-
-    // cleanup
-    l->deleteLater();
+    if (obj) {
+        m_plugins.insert(type, obj);
+    }
 
     return obj;
 }
@@ -127,6 +126,7 @@ void Integrations::load() {
         // if the plugin is the config, but not in the plugins directory
         if (obj == nullptr) {
             m_integrationsToLoad--;
+            continue;
         }
 
         // push the config to the integration
@@ -137,7 +137,7 @@ void Integrations::load() {
         createInstance(obj, map);
     }
 
-    if (m_integrationsToLoad == 0) {
+    if (m_integrationsToLoad == 0 || m_integrationsLoaded == m_integrationsToLoad) {
         emit loadComplete();
     }
 }


### PR DESCRIPTION
If an integration failed to load during startup the remote hung with the spinning cycle of death.
This fix should hopefully cover all failed integration loading.
Most common case is if an integration plugin was compiled with an incompatible Qt version.
Furthermore the failed integration is no longer added to the integration list to avoid possible further errors.