### PR TITLE
feat: Enhanced API logging

### DIFF
--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -206,7 +206,7 @@ int main(int argc, char* argv[]) {
     bool ok;
     int webSocketPort = qEnvironmentVariableIntValue("YIO_WEBSOCKET_PORT", &ok);
     yioapi->setWebSocketPort(ok ? webSocketPort : 946);
-    yioapi->setLogMsgPayload(true);
+    yioapi->setLogMsgPayload(qEnvironmentVariableIntValue("YIO_API_LOG_MSG_PAYLOAD") == 1);
     engine.rootContext()->setContextProperty("api", yioapi);
 
     // FACTORY RESET HANDLER

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -206,6 +206,7 @@ int main(int argc, char* argv[]) {
     bool ok;
     int webSocketPort = qEnvironmentVariableIntValue("YIO_WEBSOCKET_PORT", &ok);
     yioapi->setWebSocketPort(ok ? webSocketPort : 946);
+    yioapi->setLogMsgPayload(true);
     engine.rootContext()->setContextProperty("api", yioapi);
 
     // FACTORY RESET HANDLER

--- a/sources/yioapi.cpp
+++ b/sources/yioapi.cpp
@@ -113,8 +113,7 @@ bool YioAPI::setConfig(QVariantMap config) {
             qCWarning(lcApi).noquote().nospace() << "Invalid configuration:\n"
                                                  << json << "\nValidation error: " << m_config->getError();
         } else {
-            qCWarning(lcApi).noquote() << "Error setting invalid configuration. Validation error:"
-                                       << m_config->getError();
+            qCWarning(lcApi).noquote() << "Error setting invalid configuration:" << m_config->getError();
         }
         return false;
     }
@@ -812,7 +811,7 @@ void YioAPI::apiSendResponse(QWebSocket *client, int id, bool success, QVariantM
     if (m_logMsgPayload) {
         qCDebug(lcApi).noquote().nospace() << "MSG OUT (" << client->peerAddress().toString() << "): " << message;
     } else {
-        WEBSOCKET_CLIENT_DEBUG("Sent response to client")
+        WEBSOCKET_CLIENT_DEBUG(QString("Sent %1 response to client").arg(success ? "success" : "error"))
     }
 }
 
@@ -999,7 +998,6 @@ void YioAPI::apiIntegrationsDiscover(QWebSocket *client, int id) {
     timeOutTimer->setSingleShot(true);
 
     connect(timeOutTimer, &QTimer::timeout, this, [=]() {
-        qCDebug(lcApi) << "API Discovery timeout.";
         QVariantMap response;
         response.insert("message", "discovery_done");
         qCDebug(lcApi) << "API Discovery timeout, response created.";

--- a/sources/yioapi.h
+++ b/sources/yioapi.h
@@ -46,6 +46,13 @@ class YioAPI : public YioAPIInterface {
     bool    running() const { return m_running; }
     QString hostname() const { return m_hostname; }
 
+    /**
+     * @brief Enables message payload logging
+     * @details Warning: this is only intended for debugging. It's very verbose and exposes access tokens in the log!
+     */
+    void setLogMsgPayload(bool enabled) { m_logMsgPayload = enabled; }
+    bool isLogMsgPayload() const { return m_logMsgPayload; }
+
     Q_INVOKABLE void start() override;
     Q_INVOKABLE void stop() override;
     /**
@@ -53,7 +60,7 @@ class YioAPI : public YioAPIInterface {
      */
     Q_INVOKABLE void sendMessage(QString message) override;
 
-    void setWebSocketPort(quint16 port) { m_port = port; }
+    void    setWebSocketPort(quint16 port) { m_port = port; }
     quint16 webSocketPort() { return m_port; }
 
     // CONFIG MANIPULATION METHODS
@@ -73,8 +80,6 @@ class YioAPI : public YioAPIInterface {
     Q_INVOKABLE void discoverNetworkServices(QString mdns) override;
 
  signals:
-    //    void closed();
-    //    void messageReceived(QVariantMap message);
     void runningChanged();
     void hostnameChanged();
     void buttonPressed(QString button);
@@ -83,7 +88,7 @@ class YioAPI : public YioAPIInterface {
  public slots:
     void onClosed();
     void onNewConnection();
-    void processMessage(QString message);
+    void processMessage(const QString& message);
     void onClientDisconnected();
 
  private:
@@ -93,60 +98,69 @@ class YioAPI : public YioAPIInterface {
     void subscribeOnSignalEvent(const QString& event);
 
     // API CALLS
-    void apiSendResponse(QWebSocket* client, const int& id, const bool& success, QVariantMap response);
+    /**
+     * @brief Helper method to send a success response without additional payload
+     */
+    void apiSendSuccessResponse(QWebSocket* client, int id);
+    /**
+     * @brief Helper method to send an error response without additional payload
+     */
+    void apiSendErrorResponse(QWebSocket* client, int id);
+    void apiSendResponse(QWebSocket* client, int id, bool success, QVariantMap* response);
 
     void apiAuth(QWebSocket* client, const QVariantMap& map);
 
-    void apiSystemButton(const int& id, const QVariantMap& map);
-    void apiSystemReboot(QWebSocket* client, const int& id);
-    void apiSystemShutdown(QWebSocket* client, const int& id);
-    void apiSystemSubscribeToEvents(QWebSocket* client, const int& id);
-    void apiSystemUnsubscribeFromEvents(QWebSocket* client, const int& id);
+    void apiSystemButton(int id, const QVariantMap& map);
+    void apiSystemReboot(QWebSocket* client, int id);
+    void apiSystemShutdown(QWebSocket* client, int id);
+    void apiSystemSubscribeToEvents(QWebSocket* client, int id);
+    void apiSystemUnsubscribeFromEvents(QWebSocket* client, int id);
 
-    void apiGetConfig(QWebSocket* client, const int& id);
-    void apiSetConfig(QWebSocket* client, const int& id, const QVariantMap& map);
+    void apiGetConfig(QWebSocket* client, int id);
+    void apiSetConfig(QWebSocket* client, int id, const QVariantMap& map);
 
-    void apiIntegrationsDiscover(QWebSocket* client, const int& id);
-    void apiIntegrationsGetSupported(QWebSocket* client, const int& id);
-    void apiIntegrationsGetLoaded(QWebSocket* client, const int& id);
-    void apiIntegrationGetData(QWebSocket* client, const int& id, const QVariantMap& map);
-    void apiIntegrationAdd(QWebSocket* client, const int& id, const QVariantMap& map);
-    void apiIntegrationUpdate(QWebSocket* client, const int& id, const QVariantMap& map);
-    void apiIntegrationRemove(QWebSocket* client, const int& id, const QVariantMap& map);
+    void apiIntegrationsDiscover(QWebSocket* client, int id);
+    void apiIntegrationsGetSupported(QWebSocket* client, int id);
+    void apiIntegrationsGetLoaded(QWebSocket* client, int id);
+    void apiIntegrationGetData(QWebSocket* client, int id, const QVariantMap& map);
+    void apiIntegrationAdd(QWebSocket* client, int id, const QVariantMap& map);
+    void apiIntegrationUpdate(QWebSocket* client, int id, const QVariantMap& map);
+    void apiIntegrationRemove(QWebSocket* client, int id, const QVariantMap& map);
 
-    void apiEntitiesGetSupported(QWebSocket* client, const int& id);
-    void apiEntitiesGetLoaded(QWebSocket* client, const int& id);
-    void apiEntitiesGetAvailable(QWebSocket* client, const int& id);
-    void apiEntitiesAdd(QWebSocket* client, const int& id, const QVariantMap& map);
-    void apiEntitiesUpdate(QWebSocket* client, const int& id, const QVariantMap& map);
-    void apiEntitiesRemove(QWebSocket* client, const int& id, const QVariantMap& map);
+    void apiEntitiesGetSupported(QWebSocket* client, int id);
+    void apiEntitiesGetLoaded(QWebSocket* client, int id);
+    void apiEntitiesGetAvailable(QWebSocket* client, int id);
+    void apiEntitiesAdd(QWebSocket* client, int id, const QVariantMap& map);
+    void apiEntitiesUpdate(QWebSocket* client, int id, const QVariantMap& map);
+    void apiEntitiesRemove(QWebSocket* client, int id, const QVariantMap& map);
 
-    void apiProfilesGetAll(QWebSocket* client, const int& id);
-    void apiProfilesSet(QWebSocket* client, const int& id, const QVariantMap& map);
-    void apiProfilesAdd(QWebSocket* client, const int& id, const QVariantMap& map);
-    void apiProfilesUpdate(QWebSocket* client, const int& id, const QVariantMap& map);
-    void apiProfilesRemove(QWebSocket* client, const int& id, const QVariantMap& map);
+    void apiProfilesGetAll(QWebSocket* client, int id);
+    void apiProfilesSet(QWebSocket* client, int id, const QVariantMap& map);
+    void apiProfilesAdd(QWebSocket* client, int id, const QVariantMap& map);
+    void apiProfilesUpdate(QWebSocket* client, int id, const QVariantMap& map);
+    void apiProfilesRemove(QWebSocket* client, int id, const QVariantMap& map);
 
-    void apiPagesGetAll(QWebSocket* client, const int& id);
-    void apiPagesAdd(QWebSocket* client, const int& id, const QVariantMap& map);
-    void apiPagesUpdate(QWebSocket* client, const int& id, const QVariantMap& map);
-    void apiPagesRemove(QWebSocket* client, const int& id, const QVariantMap& map);
+    void apiPagesGetAll(QWebSocket* client, int id);
+    void apiPagesAdd(QWebSocket* client, int id, const QVariantMap& map);
+    void apiPagesUpdate(QWebSocket* client, int id, const QVariantMap& map);
+    void apiPagesRemove(QWebSocket* client, int id, const QVariantMap& map);
 
-    void apiGroupsGetAll(QWebSocket* client, const int& id);
-    void apiGroupsAdd(QWebSocket* client, const int& id, const QVariantMap& map);
-    void apiGroupsUpdate(QWebSocket* client, const int& id, const QVariantMap& map);
-    void apiGroupsRemove(QWebSocket* client, const int& id, const QVariantMap& map);
+    void apiGroupsGetAll(QWebSocket* client, int id);
+    void apiGroupsAdd(QWebSocket* client, int id, const QVariantMap& map);
+    void apiGroupsUpdate(QWebSocket* client, int id, const QVariantMap& map);
+    void apiGroupsRemove(QWebSocket* client, int id, const QVariantMap& map);
 
-    void apiSettingsGetAllLanguages(QWebSocket* client, const int& id);
-    void apiSettingsSetLanguage(QWebSocket* client, const int& id, const QVariantMap& map);
-    void apiSettingsSetAutoBrightness(QWebSocket* client, const int& id, const QVariantMap& map);
-    void apiSettingsSetDarkMode(QWebSocket* client, const int& id, const QVariantMap& map);
+    void apiSettingsGetAllLanguages(QWebSocket* client, int id);
+    void apiSettingsSetLanguage(QWebSocket* client, int id, const QVariantMap& map);
+    void apiSettingsSetAutoBrightness(QWebSocket* client, int id, const QVariantMap& map);
+    void apiSettingsSetDarkMode(QWebSocket* client, int id, const QVariantMap& map);
 
-    void apiLoggerControl(QWebSocket* client, const int& id, const QVariantMap& map);
+    void apiLoggerControl(QWebSocket* client, int id, const QVariantMap& map);
 
  private:
     quint16                 m_port;
     bool                    m_running = false;
+    bool                    m_logMsgPayload = false;
     QWebSocketServer*       m_server;
     QMap<QWebSocket*, bool> m_clients;  // websocket client, true if authentication was successful
 
@@ -161,7 +175,7 @@ class YioAPI : public YioAPIInterface {
         "1\xFA\x90\xED\x16\xBB";
     QString m_hostname;
 
-    QZeroConf  m_zeroConf;
+    QZeroConf m_zeroConf;
 
     QStringList m_discoverableServices;
     QString     m_prevIp;


### PR DESCRIPTION
- Log validation error in setConfig.
  The schema validation error is now logged and sent back to web-configurator to simplify debugging and error analysis.
  Example error:
```
2021-02-27 15:33:26:197 CET WARN  [yio.api]:	Error setting invalid configuration: Validation failed.
Error #1
  <root> [entities] [media_player] [1] [supported_features] [24] 
    - Failed to match against any enum values.
Error #2
  <root> [entities] [media_player] [1] [supported_features] 
    - Failed to validate item #24 in array.
Error #3
  <root> [entities] [media_player] [1] 
    - Failed to validate against schema associated with property name 'supported_features'.
Error #4
  <root> [entities] [media_player] 
    - Failed to validate item #1 in array.
Error #5
  <root> [entities] 
    - Failed to validate against schema associated with property name 'media_player'.
Error #6
  <root> 
    - Failed to validate against schema associated with property name 'entities'.
	[../sources/yioapi.cpp:116]
```
- Debug feature: log message payload
  - Activated with environment variable: `YIO_API_LOG_MSG_PAYLOAD=1`
- Improved integration removal
  - Also remove non-configured integrations
- Simplified response message sending with new helper methods
