### PR TITLE
feat: Check app version in plugin loading

### DIFF
--- a/sources/launcher.h
+++ b/sources/launcher.h
@@ -38,6 +38,11 @@ class Launcher : public QObject {
      */
     bool isCompatibleIntgLibVersion(const QString &pluginIntgLibVersion);
 
+    /**
+     * @brief Returns true if the required minium app version is fulfilled
+     */
+    bool isCompatibleAppVersion(const QString &requiredMinAppVersion);
+
  private:
     QString cleanVersionString(const QString &version);
 

--- a/translations/en_US.ts
+++ b/translations/en_US.ts
@@ -608,17 +608,22 @@ to set up YIO remote</source>
 <context>
     <name>Launcher</name>
     <message>
-        <location filename="../sources/launcher.cpp" line="52"/>
+        <location filename="../sources/launcher.cpp" line="55"/>
         <source>Incompatible plugin %1: metadata missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/launcher.cpp" line="57"/>
+        <location filename="../sources/launcher.cpp" line="60"/>
         <source>Incompatible plugin %1: integration lib mismatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sources/launcher.cpp" line="64"/>
+        <location filename="../sources/launcher.cpp" line="66"/>
+        <source>Plugin %1 requires app version %2 or higher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../sources/launcher.cpp" line="73"/>
         <source>Failed to load %1</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Make sure the app version is at least the required version specified in the plugin's metadata: `dependencies/app`
Part of #532